### PR TITLE
Fix --inside-venv boolean flag to actually work

### DIFF
--- a/performance/cli.py
+++ b/performance/cli.py
@@ -202,7 +202,7 @@ def _main():
         cmd_show(options)
         sys.exit()
 
-    if not options.inside_venv:
+    if options.inside_venv:
         exec_in_virtualenv(options)
 
     from performance.cli_run import cmd_run, cmd_list, cmd_list_groups


### PR DESCRIPTION
By enablement of this bool flag, the performance benchmark first creates a
virtual environment where it installs requirements with fixed versions to get
a reproducible environment. If this flag is not set the benchmark takes
the installed requirements by OS provider. Before this patch, the default was to create the virtual environment as default

Signed-off-by: Victor Rodriguez <victor.rodriguez.bahena@intel.com>