### PR TITLE
Update sqlalchemy to v1.3.6 for Windows + Py3.8 fixes

### DIFF
--- a/pyperformance/requirements.txt
+++ b/pyperformance/requirements.txt
@@ -62,7 +62,7 @@ Chameleon==3.6.1                          # bm_chameleon
 Django==1.11.20                           # bm_django_template
 Genshi==0.7.3                             # bm_genshi
 Mako==1.0.10                              # bm_mako
-SQLAlchemy==1.3.4                         # bm_sqlalchemy_declarative
+SQLAlchemy==1.3.6                         # bm_sqlalchemy_declarative
 dulwich==0.19.11                          # dulwich_log
 mercurial==5.0; python_version < '3.0'    # bm_hg_startup
 html5lib==1.0.1                           # bm_html5lib


### PR DESCRIPTION
sqlalchemy used "time.clock" in v1.3.4 on Windows which is no longer
available with Python 3.8.0b2 and this made the benchmarks fail.
This is fixed upstream since v1.3.5:
https://github.com/sqlalchemy/sqlalchemy/issues/4731

Fixes #62