### PR TITLE
Fix installing mercurial with Python 3 and setuptools

### DIFF
--- a/pyperformance/venv.py
+++ b/pyperformance/venv.py
@@ -202,6 +202,7 @@ def create_environ(inherit_environ):
     # Needed to install Mercurial on Python 3 for hg_startup:
     # https://www.mercurial-scm.org/wiki/Python3
     env['HGPYTHON3'] = '1'
+    env['HGALLOWPYTHON3'] = '1'
 
     return env
 


### PR DESCRIPTION
hg doesn't specify Python 3 compat unless the HGALLOWPYTHON3 env var
is set, see https://www.mercurial-scm.org/repo/hg/file/5.0.2/setup.py#l10

This fixes the following error on a pyperformance run during the initial install phase:
"ERROR: Package 'mercurial' requires a different Python: 3.8.0 not in '~= 2.7'"