### PR TITLE
Update mako to 1.1.0 for Python 3.8 on Windows fixes

### DIFF
--- a/pyperformance/requirements.txt
+++ b/pyperformance/requirements.txt
@@ -61,7 +61,7 @@ Chameleon==3.6.2                          # bm_chameleon
 # https://mail.python.org/pipermail/speed/2018-January/000619.html
 Django==1.11.22                           # bm_django_template
 Genshi==0.7.3                             # bm_genshi
-Mako==1.0.14                              # bm_mako
+Mako==1.1.0                               # bm_mako
 SQLAlchemy==1.3.6                         # bm_sqlalchemy_declarative
 dulwich==0.19.11                          # dulwich_log
 mercurial==5.0.2; python_version < '3.0'  # bm_hg_startup


### PR DESCRIPTION
The last release allows mako to run on Windows with Python 3.8, see
https://github.com/sqlalchemy/mako/issues/301 for details

Fixes #63