### PR TITLE
Enable running with alternative python, inside venv

### DIFF
--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -167,7 +167,7 @@ def parse_args():
     if hasattr(options, 'python'):
         # Replace "~" with the user home directory
         options.python = os.path.expanduser(options.python)
-        # Try to the absolute path to the binary
+        # Try to get the absolute path to the binary
         abs_python = os.path.abspath(options.python)
         if not abs_python:
             print("ERROR: Unable to locate the Python executable: %r" %

--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -150,9 +150,7 @@ def parse_args():
                                "inside the virtual environment."))
         cmd.add_argument("-p", "--python",
                          help="Python executable (default: use running Python)",
-                         # See comment below
-                         # default=sys.executable
-                         )
+                         default=sys.executable)
         cmd.add_argument("--venv",
                          help="Path to the virtual environment")
 
@@ -167,23 +165,15 @@ def parse_args():
         sys.exit(1)
 
     if hasattr(options, 'python'):
-        if options.python is not None:
-            # Replace "~" with the user home directory
-            options.python = os.path.expanduser(options.python)
-            # Try to the absolute path to the binary
-            abs_python = shutil.which(options.python)
-            if not abs_python:
-                print("ERROR: Unable to locate the Python executable: %r" %
-                      options.python)
-                sys.exit(1)
-            options.python = os.path.realpath(abs_python)
-        else:
-            # It would seems like it's possible to put sys.executable as the
-            # default when calling add_argument, but for some reason it returns
-            # another value in some cases: When the python binary is a symbolic
-            # link, the sys.executable in add_argument returns the realpath, while
-            # here it returns the relative path (before following the link).
-            options.python = sys.executable
+        # Replace "~" with the user home directory
+        options.python = os.path.expanduser(options.python)
+        # Try to the absolute path to the binary
+        abs_python = os.path.abspath(options.python)
+        if not abs_python:
+            print("ERROR: Unable to locate the Python executable: %r" %
+                  options.python)
+            sys.exit(1)
+        options.python = abs_python
 
     return (parser, options)
 

--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -150,7 +150,9 @@ def parse_args():
                                "inside the virtual environment."))
         cmd.add_argument("-p", "--python",
                          help="Python executable (default: use running Python)",
-                         default=sys.executable)
+                         # See comment below
+                         # default=sys.executable
+                         )
         cmd.add_argument("--venv",
                          help="Path to the virtual environment")
 
@@ -164,7 +166,7 @@ def parse_args():
         parser.print_help()
         sys.exit(1)
 
-    if hasattr(options, 'python'):
+    if options.python is not None:
         # Replace "~" with the user home directory
         options.python = os.path.expanduser(options.python)
         # Try to the absolute path to the binary
@@ -174,6 +176,13 @@ def parse_args():
                   options.python)
             sys.exit(1)
         options.python = os.path.realpath(abs_python)
+    else:
+        # It would seems like it's possible to put sys.executable as the
+        # default when calling add_argument, but for some reason it returns
+        # another value in some cases: When the python binary is a symbolic
+        # link, the sys.executable in add_argument returns the realpath, while
+        # here it returns the relative path (before following the link).
+        options.python = sys.executable
 
     return (parser, options)
 

--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -166,23 +166,24 @@ def parse_args():
         parser.print_help()
         sys.exit(1)
 
-    if options.python is not None:
-        # Replace "~" with the user home directory
-        options.python = os.path.expanduser(options.python)
-        # Try to the absolute path to the binary
-        abs_python = shutil.which(options.python)
-        if not abs_python:
-            print("ERROR: Unable to locate the Python executable: %r" %
-                  options.python)
-            sys.exit(1)
-        options.python = os.path.realpath(abs_python)
-    else:
-        # It would seems like it's possible to put sys.executable as the
-        # default when calling add_argument, but for some reason it returns
-        # another value in some cases: When the python binary is a symbolic
-        # link, the sys.executable in add_argument returns the realpath, while
-        # here it returns the relative path (before following the link).
-        options.python = sys.executable
+    if hasattr(options, 'python'):
+        if options.python is not None:
+            # Replace "~" with the user home directory
+            options.python = os.path.expanduser(options.python)
+            # Try to the absolute path to the binary
+            abs_python = shutil.which(options.python)
+            if not abs_python:
+                print("ERROR: Unable to locate the Python executable: %r" %
+                      options.python)
+                sys.exit(1)
+            options.python = os.path.realpath(abs_python)
+        else:
+            # It would seems like it's possible to put sys.executable as the
+            # default when calling add_argument, but for some reason it returns
+            # another value in some cases: When the python binary is a symbolic
+            # link, the sys.executable in add_argument returns the realpath, while
+            # here it returns the relative path (before following the link).
+            options.python = sys.executable
 
     return (parser, options)
 

--- a/pyperformance/cli_run.py
+++ b/pyperformance/cli_run.py
@@ -26,7 +26,9 @@ def cmd_run(parser, options):
         print("ERROR: the output file %s already exists!" % options.output)
         sys.exit(1)
 
-    executable = options.python
+    executable = sys.executable
+    if hasattr(options, 'python'):
+        executable = options.python
     if not os.path.isabs(executable):
         print("ERROR: \"%s\" is not an absolute path" % executable)
         sys.exit(1)

--- a/pyperformance/cli_run.py
+++ b/pyperformance/cli_run.py
@@ -26,9 +26,10 @@ def cmd_run(parser, options):
         print("ERROR: the output file %s already exists!" % options.output)
         sys.exit(1)
 
-    executable = sys.executable
     if hasattr(options, 'python'):
         executable = options.python
+    else:
+        executable = sys.executable
     if not os.path.isabs(executable):
         print("ERROR: \"%s\" is not an absolute path" % executable)
         sys.exit(1)

--- a/pyperformance/cli_run.py
+++ b/pyperformance/cli_run.py
@@ -26,11 +26,12 @@ def cmd_run(parser, options):
         print("ERROR: the output file %s already exists!" % options.output)
         sys.exit(1)
 
-    if not os.path.isabs(sys.executable):
-        print("ERROR: sys.executable is not an absolute path")
+    executable = options.python
+    if not os.path.isabs(executable):
+        print("ERROR: \"%s\" is not an absolute path" % executable)
         sys.exit(1)
     bench_funcs, bench_groups, should_run = get_benchmarks_to_run(options)
-    cmd_prefix = [sys.executable]
+    cmd_prefix = [executable]
     suite, errors = run_benchmarks(bench_funcs, should_run, cmd_prefix, options)
 
     if not suite:


### PR DESCRIPTION
I wanted to run pyperformance benchmark with another executable, while using a venv for the pyperformance and benchmark packages. I had to make these changes to get it to work.