### PR TITLE
Skip the genshi benchkmark as it fails with 3.11

### DIFF
--- a/pyperformance/benchmarks/__init__.py
+++ b/pyperformance/benchmarks/__init__.py
@@ -15,7 +15,11 @@ DEFAULT_GROUP = [
     'dulwich_log',
     'fannkuch',
     'float',
-    'genshi',
+
+    # FIXME: this benchmark fails with:
+    # TypeError: code() argument 15 must be bytes, not tuple
+    # 'genshi',
+
     'go',
     'hexiom',
 
@@ -269,8 +273,8 @@ def BM_sqlite_synth(python, options):
     return run_perf_script(python, options, "sqlite_synth")
 
 
-def BM_genshi(python, options):
-    return run_perf_script(python, options, "genshi")
+# def BM_genshi(python, options):
+#     return run_perf_script(python, options, "genshi")
 
 
 def BM_sqlalchemy_declarative(python, options):

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 # FIXME:
 #
 # - REENABLE HG_STARTUP BENCHMARK.
+# - REENABLE GENSHI BENCHMARK.
 #
 # Update dependencies:
 #


### PR DESCRIPTION
relates-to: #98 