### PR TITLE
Remove comment disabling BM_html5lib function

### DIFF
--- a/pyperformance/benchmarks/__init__.py
+++ b/pyperformance/benchmarks/__init__.py
@@ -233,8 +233,8 @@ def BM_nbody(python, options):
     return run_perf_script(python, options, "nbody")
 
 
-# def BM_html5lib(python, options):
-#     return run_perf_script(python, options, "html5lib")
+def BM_html5lib(python, options):
+    return run_perf_script(python, options, "html5lib")
 
 
 def BM_richards(python, options):


### PR DESCRIPTION
It looks like it was missed in [this commit](https://github.com/python/pyperformance/commit/b92f635c96b080982a71a106c1ee20ef7e0cbc00).

This was discovered while performance testing a build of python that didn't have `_sqlite3` built, and so when running the following:

```
python -m pyperformance run --benchmarks=-sqlalchemy_declarative,-sqlalchemy_imperative,-sqlite_synth
```

One gets a KeyError on `func = bench_funcs[name]` in `run.py`, and trying to work around it (adding `-html5lib` to `--benchmarks`) doesn't work, because `__init__.py` assumes things are in a consistent state.