### PR TITLE
Fix non-devel installs.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,13 +6,15 @@ include TODO.rst
 include requirements.in
 include requirements.txt
 include runtests.py
-include pyperformance
 include tox.ini
 
 include doc/*.rst doc/images/*.png doc/images/*.jpg
 include doc/conf.py doc/Makefile doc/make.bat
 
+include pyperformance/*.py
 include pyperformance/data-files/requirements.txt
 include pyperformance/data-files/benchmarks/MANIFEST
-include pyperformance/data-files/benchmarks/base.toml
-recursive-include pyperformance/data-files/benchmarks/bm_*/* *
+include pyperformance/data-files/benchmarks/bm_*/*.toml
+include pyperformance/data-files/benchmarks/bm_*/*.py
+recursive-include pyperformance/data-files/benchmarks/bm_*/data *
+recursive-exclude pyperformance/tests *

--- a/pyperformance/__init__.py
+++ b/pyperformance/__init__.py
@@ -11,10 +11,10 @@ DATA_DIR = os.path.join(PKG_ROOT, 'data-files')
 
 
 def is_installed():
-    if _is_venv():
-        return True
     parent = os.path.dirname(PKG_ROOT)
     if not os.path.exists(os.path.join(parent, 'setup.py')):
+        return True
+    if _is_venv():
         return True
     return _is_devel_install()
 

--- a/pyperformance/__init__.py
+++ b/pyperformance/__init__.py
@@ -1,4 +1,5 @@
 import os.path
+import sys
 
 
 VERSION = (1, 0, 3)
@@ -10,5 +11,32 @@ DATA_DIR = os.path.join(PKG_ROOT, 'data-files')
 
 
 def is_installed():
+    if _is_venv():
+        return True
     parent = os.path.dirname(PKG_ROOT)
-    return not os.path.exists(os.path.join(parent, 'setup.py'))
+    if not os.path.exists(os.path.join(parent, 'setup.py')):
+        return True
+    return _is_devel_install()
+
+
+def _is_venv():
+    if sys.base_prefix == sys.prefix:
+        return False
+    return True
+
+
+def _is_devel_install():
+    # pip install <path-to-git-checkout> will do a "devel" install.
+    # This means it creates a link back to the checkout instead
+    # of copying the files.
+    try:
+        import toml
+    except ModuleNotFoundError:
+        return False
+    sitepackages = os.path.dirname(toml.__file__)
+    if os.path.isdir(os.path.join(sitepackages, 'pyperformance')):
+        return False
+    if not os.path.exists(os.path.join(sitepackages, 'pyperformance.egg-link')):
+        # XXX Check the contents?
+        return False
+    return True

--- a/pyperformance/__init__.py
+++ b/pyperformance/__init__.py
@@ -11,4 +11,4 @@ DATA_DIR = os.path.join(PKG_ROOT, 'data-files')
 
 def is_installed():
     parent = os.path.dirname(PKG_ROOT)
-    return os.path.exists(os.path.join(parent, 'setup.py'))
+    return not os.path.exists(os.path.join(parent, 'setup.py'))

--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -256,8 +256,11 @@ def _main():
     parser, options = parse_args()
 
     if options.action == 'venv':
-        with _might_need_venv(options):
-            benchmarks = _benchmarks_from_options(options)
+        if options.venv_action in ('create', 'recreate'):
+            with _might_need_venv(options):
+                benchmarks = _benchmarks_from_options(options)
+        else:
+            benchmarks = None
         cmd_venv(options, benchmarks)
         sys.exit()
     elif options.action == 'compile':

--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -251,8 +251,7 @@ def _select_benchmarks(raw, manifest):
 def _main():
     parser, options = parse_args()
 
-    if not is_installed():
-        assert not options.inside_venv
+    if not is_installed() and not options.inside_venv:
         print('switching to a venv.', flush=True)
         exec_in_virtualenv(options)
 

--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -198,17 +198,13 @@ def parse_args():
     return (parser, options)
 
 
-def _needs_venv(options):
-    if is_installed():
-        return False
-    if not hasattr(options, 'python'):
-        return False
-    return not options.inside_venv
-
-
 @contextlib.contextmanager
 def _might_need_venv(options):
     try:
+        if not is_installed():
+            # Always force a local checkout to be installed.
+            assert not options.inside_venv
+            raise ModuleNotFoundError
         yield
     except ModuleNotFoundError:
         if not options.inside_venv:
@@ -258,10 +254,6 @@ def _select_benchmarks(raw, manifest):
 
 def _main():
     parser, options = parse_args()
-
-    if _needs_venv(options):
-        print('switching to a venv.', flush=True)
-        exec_in_virtualenv(options)
 
     if options.action == 'venv':
         with _might_need_venv(options):

--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -198,6 +198,14 @@ def parse_args():
     return (parser, options)
 
 
+def _needs_venv(options):
+    if is_installed():
+        return False
+    if not hasattr(options, 'python'):
+        return False
+    return not options.inside_venv
+
+
 @contextlib.contextmanager
 def _might_need_venv(options):
     try:
@@ -251,7 +259,7 @@ def _select_benchmarks(raw, manifest):
 def _main():
     parser, options = parse_args()
 
-    if not is_installed() and not options.inside_venv:
+    if _needs_venv(options):
         print('switching to a venv.', flush=True)
         exec_in_virtualenv(options)
 

--- a/pyperformance/tests/test_compare.py
+++ b/pyperformance/tests/test_compare.py
@@ -45,6 +45,7 @@ class CompareTests(unittest.TestCase):
         else:
             file1 = 'py36.json'
             file2 = kw.get('file2', 'py38.json')
+        marker = file1
 
         cmd = [sys.executable, '-m', 'pyperformance', 'compare',
                os.path.join(DATA_DIR, file1),
@@ -55,6 +56,8 @@ class CompareTests(unittest.TestCase):
                                 universal_newlines=True)
         stdout = proc.communicate()[0]
         self.assertEqual(proc.returncode, exitcode, repr(stdout))
+        if marker in stdout:
+            stdout = stdout[stdout.index(marker):]
         return stdout.rstrip() + "\n"
 
     def test_compare(self):

--- a/pyperformance/venv.py
+++ b/pyperformance/venv.py
@@ -549,10 +549,6 @@ def exec_in_virtualenv(options):
 
 
 def cmd_venv(options, benchmarks=None):
-    action = options.venv_action
-
-    requirements = Requirements.from_benchmarks(benchmarks)
-
     venv = VirtualEnvironment(
         options.python,
         options.venv,
@@ -561,7 +557,9 @@ def cmd_venv(options, benchmarks=None):
     venv_path = venv.get_path()
     exists = venv.exists()
 
+    action = options.venv_action
     if action == 'create':
+        requirements = Requirements.from_benchmarks(benchmarks)
         if exists:
             print("The virtual environment %s already exists" % venv_path)
         venv.ensure()
@@ -570,6 +568,7 @@ def cmd_venv(options, benchmarks=None):
             print("The virtual environment %s has been created" % venv_path)
 
     elif action == 'recreate':
+        requirements = Requirements.from_benchmarks(benchmarks)
         if exists:
             if venv.get_python_program() == sys.executable:
                 print("The virtual environment %s already exists" % venv_path)
@@ -599,14 +598,13 @@ def cmd_venv(options, benchmarks=None):
     else:
         # show command
         text = "Virtual environment path: %s" % venv_path
-        created = venv.exists()
-        if created:
+        if exists:
             text += " (already created)"
         else:
             text += " (not created yet)"
         print(text)
 
-        if not created:
+        if not exists:
             print()
             print("Command to create it:")
             cmd = "%s -m pyperformance venv create" % options.python

--- a/pyperformance/venv.py
+++ b/pyperformance/venv.py
@@ -114,10 +114,12 @@ class Requirements(object):
 
 def safe_rmtree(path):
     if not os.path.exists(path):
-        return
+        return False
 
     print("Remove directory %s" % path)
+    # XXX Pass onerror to report on any files that could not be deleted?
     shutil.rmtree(path)
+    return True
 
 
 def python_implementation():
@@ -577,7 +579,7 @@ def cmd_venv(options, benchmarks=None):
                 venv.install_reqs(requirements, exitonerror=True)
             else:
                 print("The virtual environment %s already exists" % venv_path)
-                shutil.rmtree(venv_path)
+                safe_rmtree(venv_path)
                 print("The old virtual environment %s has been removed" % venv_path)
                 print()
                 venv.ensure()
@@ -589,8 +591,7 @@ def cmd_venv(options, benchmarks=None):
             print("The virtual environment %s has been created" % venv_path)
 
     elif action == 'remove':
-        if os.path.exists(venv_path):
-            shutil.rmtree(venv_path)
+        if safe_rmtree(venv_path):
             print("The virtual environment %s has been removed" % venv_path)
         else:
             print("The virtual environment %s does not exist" % venv_path)

--- a/pyperformance/venv.py
+++ b/pyperformance/venv.py
@@ -20,6 +20,7 @@ PERFORMANCE_ROOT = os.path.realpath(os.path.dirname(__file__))
 REQUIREMENTS_FILE = os.path.join(pyperformance.DATA_DIR, 'requirements.txt')
 
 
+# XXX Use pyperformance.is_installed() instead?
 def is_build_dir():
     root_dir = os.path.join(PERFORMANCE_ROOT, '..')
     if not os.path.exists(os.path.join(root_dir, 'pyperformance')):


### PR DESCRIPTION
(for #120)

In some cases the wrong files were getting installed.

Also, running from a development env (AKA, git checkout) causes pyperformance to get installed into a venv.  However, pip treats this as a "develop" install and the venv basically has a link back to the original files (rather than making a copy).  This lead to incorrect logic when detecting "is installed"

Both issues are resolved here.