### PR TITLE
Remove unused var from fannkuch

### DIFF
--- a/pyperformance/data-files/benchmarks/bm_fannkuch/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_fannkuch/run_benchmark.py
@@ -16,16 +16,12 @@ def fannkuch(n):
     max_flips = 0
     m = n - 1
     r = n
-    check = 0
     perm1 = list(range(n))
     perm = list(range(n))
     perm1_ins = perm1.insert
     perm1_pop = perm1.pop
 
     while 1:
-        if check < 30:
-            check += 1
-
         while r != 1:
             count[r - 1] = r
             r -= 1


### PR DESCRIPTION
Not sure what the philosophy on changes to the benchmarks themselves is in this repo; the theory of this PR is that the benchmarks are intended to be reasonable representations of the most efficient way to accomplish a given (admittedly meaningless) task in Python with the correct result, and it doesn't make sense to have pure wasted work in the benchmarks.

This `check` var is initialized and incremented, but never used, and plays no role in returning the correct result.