### PR TITLE
Fix CPython 3.11 failures

### DIFF
--- a/pyperformance/data-files/benchmarks/bm_genshi/requirements.txt
+++ b/pyperformance/data-files/benchmarks/bm_genshi/requirements.txt
@@ -1,3 +1,2 @@
-# genshi 0.7.5+:
-git+git://github.com/edgewall/genshi.git@d5975012c4175bcca16ccf4928fdd54dcd211940
+genshi==0.7.6
 six==1.16.0

--- a/pyperformance/data-files/benchmarks/bm_genshi/requirements.txt
+++ b/pyperformance/data-files/benchmarks/bm_genshi/requirements.txt
@@ -1,2 +1,3 @@
-genshi==0.7.5
+# genshi 0.7.5+:
+git+git://github.com/edgewall/genshi.git@d5975012c4175bcca16ccf4928fdd54dcd211940
 six==1.16.0

--- a/pyperformance/data-files/benchmarks/bm_sqlalchemy_declarative/requirements.txt
+++ b/pyperformance/data-files/benchmarks/bm_sqlalchemy_declarative/requirements.txt
@@ -1,2 +1,2 @@
-greenlet==1.1.0
+greenlet==2.0.0a1
 sqlalchemy==1.4.19

--- a/pyperformance/data-files/benchmarks/bm_sqlalchemy_imperative/requirements.txt
+++ b/pyperformance/data-files/benchmarks/bm_sqlalchemy_imperative/requirements.txt
@@ -1,2 +1,2 @@
-greenlet==1.1.0
+greenlet==2.0.0a1
 sqlalchemy==1.4.19

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 # FIXME:
 #
 # - REENABLE HG_STARTUP BENCHMARK.
-# - REENABLE GENSHI BENCHMARK.
 #
 # Update dependencies:
 #


### PR DESCRIPTION
Update the pinned versions of `genshi` and `greenlet` to recent ones that work on all branch heads. Fixes #113.