### PR TITLE
Replace `a = a + b` to `a += b` for strings

### DIFF
--- a/pyperformance/compile.py
+++ b/pyperformance/compile.py
@@ -494,7 +494,7 @@ class BenchmarkRevision(Application):
             patch = os.path.basename(self.patch)
             patch = os.path.splitext(patch)[0]
             filename = "%s-patch-%s" % (filename, patch)
-        filename = filename + ".json.gz"
+        filename += ".json.gz"
         if self.patch:
             self.filename = os.path.join(self.conf.json_patch_dir, filename)
         else:

--- a/pyperformance/data-files/benchmarks/bm_2to3/data/2to3/urlresolvers.py.txt
+++ b/pyperformance/data-files/benchmarks/bm_2to3/data/2to3/urlresolvers.py.txt
@@ -347,7 +347,7 @@ def reverse(viewname, urlconf=None, args=None, kwargs=None, prefix=None, current
             try:
                 extra, resolver = resolver.namespace_dict[ns]
                 resolved_path.append(ns)
-                prefix = prefix + extra
+                prefix += extra
             except KeyError, key:
                 if resolved_path:
                     raise NoReverseMatch("%s is not a registered namespace inside '%s'" % (key, ':'.join(resolved_path)))

--- a/pyperformance/data-files/benchmarks/bm_raytrace/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_raytrace/run_benchmark.py
@@ -326,7 +326,7 @@ class SimpleSurface(object):
             for lightPoint in scene.visibleLights(p):
                 contribution = (lightPoint - p).normalized().dot(normal)
                 if contribution > 0:
-                    lambertAmount = lambertAmount + contribution
+                    lambertAmount += contribution
             lambertAmount = min(1, lambertAmount)
             c = addColours(c, self.lambertCoefficient * lambertAmount, b)
 

--- a/runtests.py
+++ b/runtests.py
@@ -37,7 +37,7 @@ def run_tests(venv):
         venv_python = os.path.join(venv, 'bin', 'python')
 
     def run_bench(*cmd):
-        cmd = cmd + ('--venv', venv)
+        cmd += ('--venv', venv)
         run_cmd(cmd)
 
     run_bench(python, '-u', script, 'venv', 'create', '-b', 'all')


### PR DESCRIPTION
According to https://github.com/faster-cpython/ideas/discussions/269, concatenation of strings with writing a result back halts specialization of `BINARY_OP_INPLACE_ADD_UNICODE` opcode thus reducing performance.

In addition, this PR does the same replacement for numeric `lambertAmount` for the sake of consistency.