### PR TITLE
Require pyperformance to be installed before running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ pyperformance.egg-info/
 
 # Created by the pyperformance script
 venv/
+.venvs/
 
 # Created by the tox program
 .tox/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,8 +5,6 @@ include README.rst
 include TODO.rst
 include requirements.in
 include requirements.txt
-include runtests.py
-include tox.ini
 
 include doc/*.rst doc/images/*.png doc/images/*.jpg
 include doc/conf.py doc/Makefile doc/make.bat

--- a/dev.py
+++ b/dev.py
@@ -1,0 +1,62 @@
+# A script for running pyperformance out of the repo in dev-mode.
+
+import os.path
+import sys
+
+
+REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
+VENV = os.path.join(REPO_ROOT, '.venvs', 'dev')
+
+
+def main(venvroot=None):
+    if sys.prefix != sys.base_prefix:  # already in a venv
+        assert os.path.exists(os.path.join(sys.prefix, 'pyvenv.cfg'))
+        # Make sure the venv has pyperformance installed.
+        ready = os.path.join(sys.prefix, 'READY')
+        if not os.path.exists(ready):
+            import subprocess
+            relroot = os.path.relpath(sys.prefix)
+            print(f'venv {relroot} not ready, installing dependencies...')
+            proc = subprocess.run(
+                [sys.executable, '-m', 'pip', 'install',
+                 '--upgrade',
+                 '--editable', REPO_ROOT],
+            )
+            if proc.returncode != 0:
+                sys.exit('ERROR: install failed')
+            with open(ready, 'w'):
+                pass
+            print('...venv {relroot} ready!')
+        # Now run pyperformance.
+        import pyperformance.cli
+        pyperformance.cli.main()
+    else:
+        import venv
+        if not venvroot:
+            import sysconfig
+            if sysconfig.is_python_build():
+                sys.exit('please install your built Python first (or pass it using --python)')
+            # XXX Handle other implementations too?
+            major, minor = sys.version_info[:2]
+            pyloc = ((os.path.abspath(sys.executable)
+                      ).partition(os.path.sep)[2].lstrip(os.path.sep)
+                     ).replace(os.path.sep, '-')
+            venvroot = f'{VENV}-{major}.{minor}-{pyloc}'
+        # Make sure the venv exists.
+        ready = os.path.join(venvroot, 'READY')
+        if not os.path.exists(ready):
+            relroot = os.path.relpath(venvroot)
+            if not os.path.exists(venvroot):
+                print(f'creating venv at {relroot}...')
+            else:
+                print(f'venv {relroot} not ready, re-creating...')
+            venv.create(venvroot, with_pip=True, clear=True)
+        # Now re-run dev.py using the venv.
+        binname = 'Scripts' if os.name == 'nt' else 'bin'
+        exename = os.path.basename(sys.executable)
+        python = os.path.join(venvroot, binname, exename)
+        os.execv(python, [python, *sys.argv])
+
+
+if __name__ == '__main__':
+    main()

--- a/pyperformance/__init__.py
+++ b/pyperformance/__init__.py
@@ -11,12 +11,16 @@ DATA_DIR = os.path.join(PKG_ROOT, 'data-files')
 
 
 def is_installed():
-    parent = os.path.dirname(PKG_ROOT)
-    if not os.path.exists(os.path.join(parent, 'setup.py')):
+    if not is_dev():
         return True
     if _is_venv():
         return True
     return _is_devel_install()
+
+
+def is_dev():
+    parent = os.path.dirname(PKG_ROOT)
+    return os.path.exists(os.path.join(parent, 'setup.py'))
 
 
 def _is_venv():

--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -1,11 +1,10 @@
 import argparse
-import contextlib
 import logging
 import os.path
 import sys
 
-from pyperformance import _utils, is_installed
-from pyperformance.venv import exec_in_virtualenv, cmd_venv
+from pyperformance import _utils, is_installed, is_dev
+from pyperformance.venv import cmd_venv
 
 
 def comma_separated(values):
@@ -158,10 +157,6 @@ def parse_args():
                                "names that are inherited from the parent "
                                "environment when running benchmarking "
                                "subprocesses."))
-        cmd.add_argument("--inside-venv", action="store_true",
-                         help=("Option for internal usage only, don't use "
-                               "it directly. Notice that we are already "
-                               "inside the virtual environment."))
         cmd.add_argument("-p", "--python",
                          help="Python executable (default: use running Python)",
                          default=sys.executable)
@@ -196,21 +191,6 @@ def parse_args():
             options.benchmarks = None
 
     return (parser, options)
-
-
-@contextlib.contextmanager
-def _might_need_venv(options):
-    try:
-        if not is_installed():
-            # Always force a local checkout to be installed.
-            assert not options.inside_venv
-            raise ModuleNotFoundError
-        yield
-    except ModuleNotFoundError:
-        if not options.inside_venv:
-            print('switching to a venv.', flush=True)
-            exec_in_virtualenv(options)
-        raise  # re-raise
 
 
 def _manifest_from_options(options):
@@ -253,6 +233,13 @@ def _select_benchmarks(raw, manifest):
 
 
 def _main():
+    if not is_installed():
+        # Always require a local checkout to be installed.
+        print('ERROR: pyperformance should not be run without installing first')
+        if is_dev():
+            print('(consider using the dev.py script)')
+        sys.exit(1)
+
     parser, options = parse_args()
 
     if options.action == 'venv':
@@ -280,23 +267,19 @@ def _main():
         cmd_show(options)
         sys.exit()
     elif options.action == 'run':
-        with _might_need_venv(options):
-            from pyperformance.cli_run import cmd_run
-            benchmarks = _benchmarks_from_options(options)
+        from pyperformance.cli_run import cmd_run
+        benchmarks = _benchmarks_from_options(options)
         cmd_run(options, benchmarks)
     elif options.action == 'compare':
-        with _might_need_venv(options):
-            from pyperformance.compare import cmd_compare
+        from pyperformance.compare import cmd_compare
         cmd_compare(options)
     elif options.action == 'list':
-        with _might_need_venv(options):
-            from pyperformance.cli_run import cmd_list
-            benchmarks = _benchmarks_from_options(options)
+        from pyperformance.cli_run import cmd_list
+        benchmarks = _benchmarks_from_options(options)
         cmd_list(options, benchmarks)
     elif options.action == 'list_groups':
-        with _might_need_venv(options):
-            from pyperformance.cli_run import cmd_list_groups
-            manifest = _manifest_from_options(options)
+        from pyperformance.cli_run import cmd_list_groups
+        manifest = _manifest_from_options(options)
         cmd_list_groups(manifest)
     else:
         parser.print_help()

--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -244,8 +244,7 @@ def _main():
 
     if options.action == 'venv':
         if options.venv_action in ('create', 'recreate'):
-            with _might_need_venv(options):
-                benchmarks = _benchmarks_from_options(options)
+            benchmarks = _benchmarks_from_options(options)
         else:
             benchmarks = None
         cmd_venv(options, benchmarks)

--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -135,19 +135,21 @@ def parse_args():
     cmds.append(cmd)
 
     # venv
-    cmd = subparsers.add_parser('venv',
+    venv_common = argparse.ArgumentParser(add_help=False)
+    venv_common.add_argument("--venv", help="Path to the virtual environment")
+    cmd = subparsers.add_parser('venv', parents=[venv_common],
                                 help='Actions on the virtual environment')
     cmd.set_defaults(venv_action='show')
     venvsubs = cmd.add_subparsers(dest="venv_action")
-    cmd = venvsubs.add_parser('show')
+    cmd = venvsubs.add_parser('show', parents=[venv_common])
     cmds.append(cmd)
-    cmd = venvsubs.add_parser('create')
+    cmd = venvsubs.add_parser('create', parents=[venv_common])
     filter_opts(cmd, allow_no_benchmarks=True)
     cmds.append(cmd)
-    cmd = venvsubs.add_parser('recreate')
+    cmd = venvsubs.add_parser('recreate', parents=[venv_common])
     filter_opts(cmd, allow_no_benchmarks=True)
     cmds.append(cmd)
-    cmd = venvsubs.add_parser('remove')
+    cmd = venvsubs.add_parser('remove', parents=[venv_common])
     cmds.append(cmd)
 
     for cmd in cmds:
@@ -160,8 +162,6 @@ def parse_args():
         cmd.add_argument("-p", "--python",
                          help="Python executable (default: use running Python)",
                          default=sys.executable)
-        cmd.add_argument("--venv",
-                         help="Path to the virtual environment")
 
     options = parser.parse_args()
 

--- a/pyperformance/run.py
+++ b/pyperformance/run.py
@@ -60,20 +60,15 @@ def run_benchmarks(should_run, python, options):
 
     benchmarks = {}
     venvs = set()
-    if options.venv:
-        venv = _venv.VirtualEnvironment(
-            options.python,
-            options.venv,
-            inherit_environ=options.inherit_environ,
-        )
-        venv.ensure(refresh=False)
-        venvs.add(venv.get_path())
+    if sys.prefix != sys.base_prefix:
+        venvs.add(sys.prefix)
+    common_venv = None  # XXX Add the ability to combine venvs.
     for i, bench in enumerate(to_run):
         bench_runid = runid._replace(bench=bench)
         assert bench_runid.name, (bench, bench_runid)
         venv = _venv.VirtualEnvironment(
             options.python,
-            options.venv,
+            common_venv,
             inherit_environ=options.inherit_environ,
             name=bench_runid.name,
             usebase=True,

--- a/pyperformance/tests/__init__.py
+++ b/pyperformance/tests/__init__.py
@@ -116,10 +116,7 @@ class Functional:
     def venv_python(self):
         return resolve_venv_python(self._VENV)
 
-    def run_pyperformance(self, cmd, *args, invenv=True):
-        if invenv:
-            assert self._VENV
-            args += ('--venv', self._VENV)
+    def run_pyperformance(self, cmd, *args):
         run_cmd(
             sys.executable, '-u', '-m', 'pyperformance',
             cmd, *args,

--- a/pyperformance/tests/test_pythoninfo.py
+++ b/pyperformance/tests/test_pythoninfo.py
@@ -40,11 +40,14 @@ class GetPythonInfoTests(tests.Resources, unittest.TestCase):
 
     def test_venv(self):
         self.maxDiff = 80 * 100
-        venv, python = self.venv()
         expected = dict(INFO)
-        expected['executable'] = python
-        expected['prefix'] = venv
-        expected['exec_prefix'] = venv
+        if sys.prefix != sys.base_prefix:
+            python = sys.executable
+        else:
+            venv, python = self.venv()
+            expected['executable'] = python
+            expected['prefix'] = venv
+            expected['exec_prefix'] = venv
 
         info = _pythoninfo.get_python_info(python)
 
@@ -80,12 +83,39 @@ class GetPythonIDTests(unittest.TestCase):
         self.assertEqual(pyid, f'spam-{self.ID}')
 
 
+def read_venv_config(venv):
+    filename = os.path.join(venv, 'pyvenv.cfg')
+    with open(filename, encoding='utf-8') as infile:
+        text = infile.read()
+    cfg = {}
+    for line in text.splitlines():
+        name, sep, value = line.partition(' = ')
+        if sep:
+            cfg[name.strip()] = value.strip()
+    return cfg
+
+
+def get_venv_base(venv):
+    cfg = read_venv_config(sys.prefix)
+    if 'executable' in cfg:
+        return cfg['executable']
+    elif 'home' in cfg:
+        major, minor = cfg['version'].split('.')[:2]
+        base = f'python{major}.{minor}'
+        return os.path.join(cfg['home'], base)
+    else:
+        return None
+
+
 class InspectPythonInstallTests(tests.Resources, unittest.TestCase):
 
     BASE = getattr(sys, '_base_executable', None)
 
     def test_info(self):
-        info = INFO
+        info = dict(INFO)
+        if sys.prefix != sys.base_prefix:
+            info['prefix'] = info['base_prefix']
+            info['exec_prefix'] = info['base_exec_prefix']
         (base, isdev, isvenv,
          ) = _pythoninfo.inspect_python_install(info)
 
@@ -96,16 +126,36 @@ class InspectPythonInstallTests(tests.Resources, unittest.TestCase):
         self.assertFalse(isvenv)
 
     def test_normal(self):
+        if sys.prefix != sys.base_prefix:
+            try:
+                python = sys._base_executable
+            except AttributeError:
+                python = sys.executable
+            if python == sys.executable:
+                python = get_venv_base(sys.prefix)
+                assert python
+        else:
+            python = sys.executable
         (base, isdev, isvenv,
-         ) = _pythoninfo.inspect_python_install()
+         ) = _pythoninfo.inspect_python_install(python)
 
-        self.assertEqual(base, sys.executable)
+        self.assertEqual(base, python)
         self.assertFalse(isdev)
         self.assertFalse(isvenv)
 
     def test_venv(self):
-        base_expected = sys.executable
-        _, python = self.venv(base_expected)
+        if sys.prefix != sys.base_prefix:
+            python = sys.executable
+            try:
+                base_expected = sys._base_executable
+            except AttributeError:
+                base_expected = sys.executable
+            if base_expected == sys.executable:
+                base_expected = get_venv_base(sys.prefix)
+                assert base_expected
+        else:
+            base_expected = sys.executable
+            _, python = self.venv(base_expected)
         (base, isdev, isvenv,
          ) = _pythoninfo.inspect_python_install(python)
 

--- a/pyperformance/tests/test_show.py
+++ b/pyperformance/tests/test_show.py
@@ -12,7 +12,7 @@ class FunctionalTests(tests.Functional, unittest.TestCase):
             os.path.join(tests.DATA_DIR, 'mem1.json'),
         ):
             with self.subTest(filename):
-                self.run_pyperformance('show', filename, invenv=False)
+                self.run_pyperformance('show', filename)
 
 
 if __name__ == "__main__":

--- a/pyperformance/venv.py
+++ b/pyperformance/venv.py
@@ -527,29 +527,6 @@ class VirtualEnvironment(object):
         return requirements
 
 
-def exec_in_virtualenv(options):
-    venv = VirtualEnvironment(
-        options.python,
-        options.venv,
-        inherit_environ=options.inherit_environ,
-    )
-
-    venv.ensure()
-    venv_python = venv.get_python_program()
-
-    args = [venv_python, "-m", "pyperformance"] + \
-        sys.argv[1:] + ["--inside-venv"]
-    # os.execv() is buggy on windows, which is why we use run_cmd/subprocess
-    # on windows.
-    # * https://bugs.python.org/issue19124
-    # * https://github.com/python/benchmarks/issues/5
-    if os.name == "nt":
-        venv.run_cmd(args, verbose=False)
-        sys.exit(0)
-    else:
-        os.execv(args[0], args)
-
-
 def cmd_venv(options, benchmarks=None):
     venv = VirtualEnvironment(
         options.python,

--- a/runtests.py
+++ b/runtests.py
@@ -3,8 +3,17 @@ import os.path
 import subprocess
 import sys
 
+from dev import ensure_venv_ready
+
 
 def main():
+    python = ensure_venv_ready(kind='tests')
+    if python != sys.executable:
+        # Now re-run using the venv.
+        os.execv(python, [python, *sys.argv])
+        # <unreachable>
+
+    # Now run the tests.
     subprocess.run(
         [sys.executable, '-u', '-m', 'pyperformance.tests'],
         cwd=os.path.dirname(__file__) or None,


### PR DESCRIPTION
A number of things get simpler if we require pyperformance to always be installed.  In particular, we no longer need to create a top-level venv all the time.

This change also includes a convenience script, dev.py, to create a venv if needed.