### PR TITLE
Preserve the Exit Code of Running the Tests

### DIFF
--- a/pyperformance/tests/test_commands.py
+++ b/pyperformance/tests/test_commands.py
@@ -1,7 +1,6 @@
 import os
 import os.path
 import shutil
-import subprocess
 import sys
 import textwrap
 import unittest
@@ -30,12 +29,13 @@ class FullStackTests(tests.Functional, unittest.TestCase):
 
     @classmethod
     def ensure_pyperformance(cls):
-        _, stdout, _ = cls.run_python(
+        ec, stdout, _ = cls.run_python(
             os.path.join(tests.DATA_DIR, 'find-pyperformance.py'),
             capture='stdout',
             onfail='raise',
             verbose=False,
         )
+        self.assertEqual(ec, 0)
         stdout = stdout.strip()
         if stdout.strip():
             # It is already installed.
@@ -49,7 +49,8 @@ class FullStackTests(tests.Functional, unittest.TestCase):
         # Install it.
         reporoot = os.path.dirname(pyperformance.PKG_ROOT)
         # XXX Ignore the output (and optionally log it).
-        cls.run_pip('install', '--editable', reporoot)
+        ec, _, _ = cls.run_pip('install', '--editable', reporoot)
+        self.assertEqual(ec, 0)
 
         # Clean up extraneous files.
         egg_info = "pyperformance.egg-info"

--- a/pyperformance/tests/test_commands.py
+++ b/pyperformance/tests/test_commands.py
@@ -107,6 +107,13 @@ class FullStackTests(tests.Functional, unittest.TestCase):
             print('---')
             print()
 
+        from pyperformance import _venv
+        venv_python = _venv.resolve_venv_python(root)
+        try:
+            print('+++', os.listdir(os.path.dirname(venv_python)))
+        except FileNotFoundError:
+            print('+++ not found')
+
         # It doesn't exist yet.
         self.run_pyperformance(
             'venv', 'show', '--venv', root,

--- a/pyperformance/tests/test_commands.py
+++ b/pyperformance/tests/test_commands.py
@@ -10,6 +10,12 @@ import pyperformance
 from pyperformance import tests
 
 
+CPYTHON_ONLY = unittest.skipIf(
+    sys.implementation.name != 'cpython',
+    'CPython-only',
+)
+
+
 class FullStackTests(tests.Functional, unittest.TestCase):
 
     maxDiff = 80 * 100
@@ -252,6 +258,7 @@ class FullStackTests(tests.Functional, unittest.TestCase):
             outfile.write(text)
         return cfgfile
 
+    @CPYTHON_ONLY
     @unittest.skip('way too slow')
     def test_compile(self):
         cfgfile = self.create_compile_config()
@@ -263,6 +270,7 @@ class FullStackTests(tests.Functional, unittest.TestCase):
             capture=None,
         )
 
+    @CPYTHON_ONLY
     @unittest.skip('way too slow')
     def test_compile_all(self):
         rev1 = '2cd268a3a934'  # tag: v3.10.1
@@ -275,6 +283,7 @@ class FullStackTests(tests.Functional, unittest.TestCase):
             capture=None,
         )
 
+    @CPYTHON_ONLY
     @unittest.expectedFailure
     def test_upload(self):
         url = '<bogus>'

--- a/pyperformance/tests/test_commands.py
+++ b/pyperformance/tests/test_commands.py
@@ -107,13 +107,6 @@ class FullStackTests(tests.Functional, unittest.TestCase):
             print('---')
             print()
 
-        from pyperformance import _venv
-        venv_python = _venv.resolve_venv_python(root)
-        try:
-            print('+++', os.listdir(os.path.dirname(venv_python)))
-        except FileNotFoundError:
-            print('+++ not found')
-
         # It doesn't exist yet.
         self.run_pyperformance(
             'venv', 'show', '--venv', root,

--- a/pyperformance/tests/test_commands.py
+++ b/pyperformance/tests/test_commands.py
@@ -35,7 +35,7 @@ class FullStackTests(tests.Functional, unittest.TestCase):
             onfail='raise',
             verbose=False,
         )
-        self.assertEqual(ec, 0)
+        assert ec == 0, ec
         stdout = stdout.strip()
         if stdout.strip():
             # It is already installed.
@@ -50,7 +50,7 @@ class FullStackTests(tests.Functional, unittest.TestCase):
         reporoot = os.path.dirname(pyperformance.PKG_ROOT)
         # XXX Ignore the output (and optionally log it).
         ec, _, _ = cls.run_pip('install', '--editable', reporoot)
-        self.assertEqual(ec, 0)
+        assert ec == 0, ec
 
         # Clean up extraneous files.
         egg_info = "pyperformance.egg-info"

--- a/runtests.py
+++ b/runtests.py
@@ -14,7 +14,7 @@ def main():
         # <unreachable>
 
     # Now run the tests.
-    subprocess.run(
+    proc = subprocess.run(
         [sys.executable, '-u', '-m', 'pyperformance.tests'],
         cwd=os.path.dirname(__file__) or None,
         env=dict(
@@ -22,6 +22,7 @@ def main():
             PYPERFORMANCE_TESTS_VENV=venvroot,
         )
     )
+    sys.exit(proc.returncode)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We have been ignoring the exit code of the subprocess in runtests.py.