### PR TITLE
Always Try to Install psutil

### DIFF
--- a/pyperformance/_pip.py
+++ b/pyperformance/_pip.py
@@ -14,6 +14,16 @@ OLD_PIP = '7.1.2'
 OLD_SETUPTOOLS = '18.5'
 
 
+def get_pkg_name(req):
+    """Return the name of the package in the given requirement text."""
+    # strip env markers
+    req = req.partition(';')[0]
+    # strip version
+    req = req.partition('==')[0]
+    req = req.partition('>=')[0]
+    return req
+
+
 def get_best_pip_version(python):
     """Return the pip to install for the given Python executable."""
     if not python or isinstance(python, str):

--- a/pyperformance/venv.py
+++ b/pyperformance/venv.py
@@ -12,9 +12,9 @@ REQUIREMENTS_FILE = os.path.join(pyperformance.DATA_DIR, 'requirements.txt')
 class Requirements(object):
 
     @classmethod
-    def from_file(cls, filename, optional=None):
+    def from_file(cls, filename):
         self = cls()
-        self._add_from_file(filename, optional)
+        self._add_from_file(filename)
         return self
 
     @classmethod
@@ -32,44 +32,25 @@ class Requirements(object):
         # requirements
         self.specs = []
 
-        # optional requirements
-        self._optional = set()
-
     def __len__(self):
         return len(self.specs)
 
-    def iter_non_optional(self):
+    def __iter__(self):
         for spec in self.specs:
-            if spec in self._optional:
-                continue
             yield spec
 
-    def iter_optional(self):
-        for spec in self.specs:
-            if spec not in self._optional:
-                continue
-            yield spec
-
-    def _add_from_file(self, filename, optional=None):
+    def _add_from_file(self, filename):
         if not os.path.exists(filename):
             return
         for line in _utils.iter_clean_lines(filename):
-            self._add(line, optional)
+            self._add(line)
 
-    def _add(self, line, optional=None):
+    def _add(self, line):
         self.specs.append(line)
-        if optional:
-            # strip env markers
-            req = line.partition(';')[0]
-            # strip version
-            req = req.partition('==')[0]
-            req = req.partition('>=')[0]
-            if req in optional:
-                self._optional.add(line)
 
     def get(self, name):
         for req in self.specs:
-            if req.startswith(name):
+            if _pip.get_pkg_name(req) == name:
                 return req
         return None
 
@@ -186,7 +167,7 @@ class VenvForBenchmarks(_venv.VirtualEnvironment):
         print("installing pyperformance in the venv at %s" % self.root)
         # Install pyperformance inside the virtual environment.
         if pyperformance.is_dev():
-            basereqs = Requirements.from_file(REQUIREMENTS_FILE, ['psutil'])
+            basereqs = Requirements.from_file(REQUIREMENTS_FILE)
             self.ensure_reqs(basereqs)
 
             root_dir = os.path.dirname(pyperformance.PKG_ROOT)
@@ -216,7 +197,7 @@ class VenvForBenchmarks(_venv.VirtualEnvironment):
 
         # Every benchmark must depend on pyperf.
         if bench is not None and not requirements.get('pyperf'):
-            basereqs = Requirements.from_file(REQUIREMENTS_FILE, ['psutil'])
+            basereqs = Requirements.from_file(REQUIREMENTS_FILE)
             pyperf_req = basereqs.get('pyperf')
             if not pyperf_req:
                 raise NotImplementedError
@@ -229,21 +210,13 @@ class VenvForBenchmarks(_venv.VirtualEnvironment):
             # install requirements
             try:
                 super().ensure_reqs(
-                    *requirements.iter_non_optional(),
+                    *requirements,
                     upgrade=False,
                 )
             except _venv.RequirementsInstallationFailedError:
                 if exitonerror:
                     sys.exit(1)
                 raise  # re-raise
-
-            # install optional requirements
-            for req in requirements.iter_optional():
-                try:
-                    super().ensure_reqs(req, upgrade=True)
-                except _venv.RequirementsInstallationFailedError:
-                    print("WARNING: failed to install %s" % req)
-                    print()
 
         # Dump the package list and their versions: pip freeze
         _pip.run_pip('freeze', python=self.python, env=self._env)


### PR DESCRIPTION
(see #148)

pyperf treats psutil as an optional dependency.  Most of the time it should be installable, but we weren't really even trying.  This PR fixes that.