### PR TITLE
Genshi 0.7.7 is released, use it

### DIFF
--- a/pyperformance/data-files/benchmarks/bm_genshi/requirements.txt
+++ b/pyperformance/data-files/benchmarks/bm_genshi/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/edgewall/genshi@605de3b#egg=genshi
+genshi==0.7.7
 six==1.16.0


### PR DESCRIPTION
Instead of a direct github URL.

See https://github.com/edgewall/genshi/issues/66#issuecomment-1105149926