### PR TITLE
Add support for multiple benchmark groups in a manifest

### DIFF
--- a/pyperformance/_manifest.py
+++ b/pyperformance/_manifest.py
@@ -117,13 +117,17 @@ class BenchmarksManifest:
                     _resolve = resolve_default_benchmark
             lastfile = filename
 
+            section_key = section
+            if section == "group":
+                section_key = (section, data[0])
+
             if filename not in sections_seen:
-                sections_seen[filename] = {section}
-            elif section in sections_seen[filename]:
-                # For now each section can only show up once.
-                raise NotImplementedError((section, data))
+                sections_seen[filename] = {section_key}
+            elif section_key in sections_seen[filename]:
+                # For now each section_key can only show up once.
+                raise NotImplementedError((section_key, data))
             else:
-                sections_seen[filename].add(section)
+                sections_seen[filename].add(section_key)
 
             if section == 'includes':
                 pass

--- a/pyperformance/_manifest.py
+++ b/pyperformance/_manifest.py
@@ -419,20 +419,20 @@ def _resolve_groups(rawgroups, byname):
     while unresolved:
         for groupname, names in list(unresolved.items()):
             benchmarks = set()
-            for name in names:
+
+            q = list(names)
+            while q:
+                name = q.pop()
+
                 if name in byname:
                     benchmarks.add(byname[name])
                 elif name in groups:
                     benchmarks.update(groups[name])
-                    names.remove(name)
                 elif name == groupname:
-                    names.remove(name)
-                    break
+                    pass
                 else:  # name in unresolved
-                    names.remove(name)
-                    names.extend(unresolved[name])
-                    break
-            else:
-                groups[groupname] = benchmarks
-                del unresolved[groupname]
+                    q.extend(unresolved[name])
+
+            groups[groupname] = benchmarks
+            del unresolved[groupname]
     return groups

--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -29,7 +29,7 @@ def filter_opts(cmd, *, allow_no_benchmarks=False):
     cmd.add_argument("--manifest", help="benchmark manifest file to use")
 
     cmd.add_argument("-b", "--benchmarks", metavar="BM_LIST", default='<default>',
-                     help=("Comma-separated list of benchmarks to run.  Can"
+                     help=("Comma-separated list of benchmarks or groups to run.  Can"
                            " contain both positive and negative arguments:"
                            "  --benchmarks=run_this,also_this,-not_this.  If"
                            " there are no positive arguments, we'll run all"


### PR DESCRIPTION
Previously they would show up as conflicts on the "group" section