### PR TITLE
Proposal: Force recompilation of all dependencies

### DIFF
--- a/pyperformance/_pip.py
+++ b/pyperformance/_pip.py
@@ -153,6 +153,11 @@ def install_requirements(reqs, *extra,
         if os.path.exists(reqs):
             args.append('-r')  # --requirement
         args.append(reqs)
+
+    if "USE_BINARY_PACKAGES" not in os.environ:
+        # Force recompilation:
+        args.extend(["--no-binary", ":all:"])
+
     return run_pip('install', *args, **kwargs)
 
 


### PR DESCRIPTION
There is, in general, not a requirement that source packages compile to the same thing as available binary packages. It's rare, but this is one thing that can end up causing differences in benchmark results between two Python distributions, if one has binary packages and one does not. Forcing all dependencies to compile from source eliminates this potential difference.

The only case I know of is mypy, which ships a more-optimized binary package than what their source package compiles to.