### PR TITLE
github: Update PyPy version from 3.6 to [3.7, 3.8, 3.9]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
         os: [ubuntu-latest]
         python: ["3.7", "3.8", "3.9", "3.10", 3.11-dev]
         include:
+          # Also test PyPy, macOS, and Windows:
           - os: ubuntu-latest
             python: pypy-3.9
           - os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,13 +21,16 @@ jobs:
         os: [ubuntu-latest]
         python: ["3.7", "3.8", "3.9", "3.10", 3.11-dev]
         include:
-          # Also test PyPy, macOS, and Windows:
           - os: ubuntu-latest
-            python: pypy3
+            python: pypy-3.9
+          - os: ubuntu-latest
+            python: pypy-3.8
+          - os: ubuntu-latest
+            python: pypy-3.7
           - os: macos-latest
             python: "3.10"
           # XXX: We should be testing 3.10, but for some reason setuptools can't
-          # seem to find the runner's C compiler for new wheel builds... 
+          # seem to find the runner's C compiler for new wheel builds...
           - os: windows-latest
             python: "3.9"
     steps:


### PR DESCRIPTION
<img width="512" alt="default-pypy" src="https://user-images.githubusercontent.com/5110323/166854619-887345eb-b94e-4d4f-a51b-b288f39b1727.png">

Current GitHub Action only executes the default PyPy version of Ubuntu which is actually 3.6 and too old but we are executing the CI for CPython 3.[7-10].
We may need to expand the PyPy version to support their latest implementation and match the identical versions.