### PR TITLE
Add benchmark for deepcopy

### DIFF
--- a/doc/benchmarks.rst
+++ b/doc/benchmarks.rst
@@ -108,6 +108,11 @@ See `pyaes <https://github.com/ricmoo/pyaes>`_: A pure-Python implementation of
 the AES block cipher algorithm and the common modes of operation (CBC, CFB,
 CTR, ECB and OFB).
 
+deepcopy
+--------
+
+benchmark the pytython `copy.deepcopy` method. The `deepcopy` method is
+performed on a nestest dictionary and a dataclass.
 
 deltablue
 ---------

--- a/doc/benchmarks.rst
+++ b/doc/benchmarks.rst
@@ -111,8 +111,8 @@ CTR, ECB and OFB).
 deepcopy
 --------
 
-benchmark the pytython `copy.deepcopy` method. The `deepcopy` method is
-performed on a nestest dictionary and a dataclass.
+Benchmark the Python `copy.deepcopy` method. The `deepcopy` method is
+performed on a nested dictionary and a dataclass.
 
 deltablue
 ---------

--- a/pyperformance/data-files/benchmarks/MANIFEST
+++ b/pyperformance/data-files/benchmarks/MANIFEST
@@ -5,6 +5,7 @@ name	metafile
 chameleon	<local>
 chaos	<local>
 crypto_pyaes	<local>
+deepcopy	<local>
 deltablue	<local>
 django_template	<local>
 dulwich_log	<local>

--- a/pyperformance/data-files/benchmarks/bm_deepcopy/pyproject.toml
+++ b/pyperformance/data-files/benchmarks/bm_deepcopy/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "pyperformance_bm_deepcopy"
+requires-python = ">=3.8"
+dependencies = ["pyperf"]
+urls = {repository = "https://github.com/python/pyperformance"}
+dynamic = ["version"]
+
+[tool.pyperformance]
+name = "deepcopy"

--- a/pyperformance/data-files/benchmarks/bm_deepcopy/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_deepcopy/run_benchmark.py
@@ -18,20 +18,17 @@ class A:
     
 
 def benchmark(n):
-    a={'list': [1,2,3,43], 't': (1,2,3), 'str': 'hello', 'subdict': {'a': True}}
-    dc=A('hello', [1,2,3], True)
-    
+    a = {'list': [1,2,3,43], 't': (1,2,3), 'str': 'hello', 'subdict': {'a': True}}
+    dc = A('hello', [1,2,3], True)
     for ii in range(n):
-        
         for jj in range(60):
             _ = copy.deepcopy(a)
-            
         for s in ['red', 'blue', 'green']:
             dc.string = s
             for ii in range(10):
                 dc.lst[0] = ii
                 for b in [True, False]:
-                    dc.boolean=b
+                    dc.boolean = b
                     _ = copy.deepcopy(dc)
                 
 

--- a/pyperformance/data-files/benchmarks/bm_deepcopy/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_deepcopy/run_benchmark.py
@@ -1,0 +1,42 @@
+"""
+Benchmark to measure performance of the python builtin method copy.deepcopy
+
+Performance is tested on a nested dictionary and a dataclass
+
+Author: Pieter Eendebak
+
+"""
+import copy
+import pyperf
+from dataclasses import dataclass
+
+@dataclass
+class A:
+    string : str
+    lst : list
+    boolean : bool
+    
+
+def benchmark(n):
+    a={'list': [1,2,3,43], 't': (1,2,3), 'str': 'hello', 'subdict': {'a': True}}
+    dc=A('hello', [1,2,3], True)
+    
+    for ii in range(n):
+        
+        for jj in range(60):
+            _ = copy.deepcopy(a)
+            
+        for s in ['red', 'blue', 'green']:
+            dc.string = s
+            for ii in range(10):
+                dc.lst[0] = ii
+                for b in [True, False]:
+                    dc.boolean=b
+                    _ = copy.deepcopy(dc)
+                
+
+if __name__ == "__main__":
+    runner = pyperf.Runner()
+    runner.metadata['description'] = "deepcopy benchmark"
+
+    runner.bench_func('deepcopy', benchmark, 200)

--- a/pyperformance/data-files/benchmarks/bm_deepcopy/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_deepcopy/run_benchmark.py
@@ -61,18 +61,21 @@ def benchmark(n):
     }
     dc = A('hello', [1, 2, 3], True)
 
-    t0 = pyperf.perf_counter()
+    dt = 0
     for ii in range(n):
         for jj in range(30):
+            t0 = pyperf.perf_counter()
             _ = copy.deepcopy(a)
+            dt += pyperf.perf_counter() - t0
         for s in ['red', 'blue', 'green']:
             dc.string = s
             for kk in range(5):
                 dc.lst[0] = kk
                 for b in [True, False]:
                     dc.boolean = b
+                    t0 = pyperf.perf_counter()
                     _ = copy.deepcopy(dc)
-    dt = pyperf.perf_counter() - t0
+                    dt += pyperf.perf_counter() - t0
     return dt
 
 

--- a/pyperformance/data-files/benchmarks/bm_deepcopy/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_deepcopy/run_benchmark.py
@@ -25,8 +25,8 @@ def benchmark(n):
             _ = copy.deepcopy(a)
         for s in ['red', 'blue', 'green']:
             dc.string = s
-            for ii in range(10):
-                dc.lst[0] = ii
+            for kk in range(10):
+                dc.lst[0] = kk
                 for b in [True, False]:
                     dc.boolean = b
                     _ = copy.deepcopy(dc)

--- a/pyperformance/data-files/benchmarks/bm_deepcopy/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_deepcopy/run_benchmark.py
@@ -10,30 +10,76 @@ import copy
 import pyperf
 from dataclasses import dataclass
 
+
 @dataclass
 class A:
-    string : str
-    lst : list
-    boolean : bool
-    
+    string: str
+    lst: list
+    boolean: bool
+
+
+def benchmark_reduce(n):
+    """ Benchmark where the __reduce__ functionality is used """
+    class C(object):
+        def __init__(self):
+            self.a = 1
+            self.b = 2
+
+        def __reduce__(self):
+            return (C, (), self.__dict__)
+
+        def __setstate__(self, state):
+            self.__dict__.update(state)
+    c = C()
+
+    t0 = pyperf.perf_counter()
+    for ii in range(n):
+        _ = copy.deepcopy(c)
+    dt = pyperf.perf_counter() - t0
+    return dt
+
+
+def benchmark_memo(n):
+    """ Benchmark where the memo functionality is used """
+    A = [1] * 100
+    data = {'a': (A, A, A), 'b': [A] * 100}
+
+    t0 = pyperf.perf_counter()
+    for ii in range(n):
+        _ = copy.deepcopy(data)
+    dt = pyperf.perf_counter() - t0
+    return dt
+
 
 def benchmark(n):
-    a = {'list': [1,2,3,43], 't': (1,2,3), 'str': 'hello', 'subdict': {'a': True}}
-    dc = A('hello', [1,2,3], True)
+    """ Benchmark on some standard data types """
+    a = {
+        'list': [1, 2, 3, 43],
+        't': (1 ,2, 3),
+        'str': 'hello',
+        'subdict': {'a': True}
+    }
+    dc = A('hello', [1, 2, 3], True)
+
+    t0 = pyperf.perf_counter()
     for ii in range(n):
-        for jj in range(60):
+        for jj in range(30):
             _ = copy.deepcopy(a)
         for s in ['red', 'blue', 'green']:
             dc.string = s
-            for kk in range(10):
+            for kk in range(5):
                 dc.lst[0] = kk
                 for b in [True, False]:
                     dc.boolean = b
                     _ = copy.deepcopy(dc)
-                
+    dt = pyperf.perf_counter() - t0
+    return dt
+
 
 if __name__ == "__main__":
     runner = pyperf.Runner()
     runner.metadata['description'] = "deepcopy benchmark"
 
-    runner.bench_func('deepcopy', benchmark, 200)
+    runner.bench_time_func('deepcopy', benchmark)
+    runner.bench_time_func('deepcopy_reduce', benchmark_reduce)
+    runner.bench_time_func('deepcopy_memo', benchmark_memo)


### PR DESCRIPTION
One python method that is currently not in the pyperformance benchmarks is `deepcopy`. This PRs adds a benchmark that tests performance of `deepcopy` on a nested dictionary and a dataclass.

The dictionary and dataclass have been chosen as example of structures can are often copied and then modified. (e.g. passing configuration settings to a method that modifies one of the settings before passing it on)

Fixes #199
