### PR TITLE
Support calling `compile` command from when cwd is a source checkout

### DIFF
--- a/pyperformance/__init__.py
+++ b/pyperformance/__init__.py
@@ -30,14 +30,14 @@ def _is_venv():
 
 
 def _is_devel_install():
-    # pip install <path-to-git-checkout> will do a "devel" install.
+    # pip install -e <path-to-git-checkout> will do a "devel" install.
     # This means it creates a link back to the checkout instead
     # of copying the files.
     try:
         import toml
     except ModuleNotFoundError:
         return False
-    sitepackages = os.path.dirname(toml.__file__)
+    sitepackages = os.path.dirname(os.path.dirname(toml.__file__))
     if os.path.isdir(os.path.join(sitepackages, 'pyperformance')):
         return False
     if not os.path.exists(os.path.join(sitepackages, 'pyperformance.egg-link')):

--- a/pyperformance/compile.py
+++ b/pyperformance/compile.py
@@ -396,6 +396,7 @@ class Python(Task):
         cmd = [self.program, '-u', '-m', 'pip', 'install']
 
         if pyperformance.is_dev():
+            cmd.append('-e')
             cmd.append(os.path.dirname(pyperformance.PKG_ROOT))
         else:
             version = pyperformance.__version__


### PR DESCRIPTION
The `pyperformance compile` command currently fails when the current directory
is a source checkout, since the installation of pyperformance in the benchmark
venv is slightly broken, and the detection of running from a source checkout is
slightly broken. This is true whether using `python -m pyperformance` or `python
./dev.py` methods.

- To detect whether performance is being imported from an "installation" rather
than the source directory, it imports toml and then sees if there is a
`pyperformance` package sitting alongside it. This (perhaps) worked in the past
when `toml` was a module, but it's currently a package, so we need to go up two
levels of directories.

- `pyperformance` is installed in the benchmark venvs with `pip install .`, but
`pip install -e .` actually installs in editable/developer mode, as described
elsewhere.

I struggled to write a short-running unit test for this -- there are a lot of moving parts that need to align to reproduce this. However, there is an [existing test](https://github.com/python/pyperformance/blob/main/pyperformance/tests/test_commands.py#L244) that currently fails on main, but passes with these changes.  It's marked as `@SLOW`, so I suspect it hasn't run on CI in quite some time. I'd appreciate any thoughts about whether that's sufficient...