### PR TITLE
Add coroutines benchmark

### DIFF
--- a/pyperformance/data-files/benchmarks/MANIFEST
+++ b/pyperformance/data-files/benchmarks/MANIFEST
@@ -6,6 +6,7 @@ async_tree	<local>
 async_tree_cpu_io_mixed	<local:async_tree>
 async_tree_io	<local:async_tree>
 async_tree_memoization	<local:async_tree>
+coroutines	<local>
 coverage	<local>
 generators	<local>
 chameleon	<local>

--- a/pyperformance/data-files/benchmarks/bm_coroutines/pyproject.toml
+++ b/pyperformance/data-files/benchmarks/bm_coroutines/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "pyperformance_bm_coroutines"
+requires-python = ">=3.8"
+dependencies = ["pyperf"]
+urls = {repository = "https://github.com/python/pyperformance"}
+dynamic = ["version"]
+
+[tool.pyperformance]
+name = "coroutines"

--- a/pyperformance/data-files/benchmarks/bm_coroutines/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_coroutines/run_benchmark.py
@@ -1,0 +1,32 @@
+"""
+Benchmark for recursive coroutines.
+
+Author: Kumar Aditya
+"""
+
+import pyperf
+
+
+async def fibonacci(n: int) -> int:
+    if n <= 1:
+        return n
+    return await fibonacci(n - 1) + await fibonacci(n - 2)
+
+
+def bench_coroutines(loops: int) -> float:
+    range_it = range(loops)
+    t0 = pyperf.perf_counter()
+    for _ in range_it:
+        coro = fibonacci(25)
+        try:
+            while True:
+                coro.send(None)
+        except StopIteration:
+            pass
+    return pyperf.perf_counter() - t0
+
+
+if __name__ == "__main__":
+    runner = pyperf.Runner()
+    runner.metadata['description'] = "Benchmark coroutines"
+    runner.bench_time_func('coroutines', bench_coroutines)

--- a/pyperformance/data-files/benchmarks/bm_generators/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_generators/run_benchmark.py
@@ -33,13 +33,12 @@ def tree(input: range) -> Tree | None:
     i = n // 2
     return Tree(tree(input[:i]), input[i], tree(input[i + 1:]))
 
-def bench_generators(loops: int) -> float:
+def bench_generators(loops: int) -> None:
     assert list(tree(range(10))) == list(range(10))
     range_it = range(loops)
-    iterable = tree(range(100000))
     t0 = pyperf.perf_counter()
     for _ in range_it:
-        for _ in iterable:
+        for _ in tree(range(100000)):
             pass
     return pyperf.perf_counter() - t0
 

--- a/pyperformance/data-files/benchmarks/bm_generators/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_generators/run_benchmark.py
@@ -33,12 +33,13 @@ def tree(input: range) -> Tree | None:
     i = n // 2
     return Tree(tree(input[:i]), input[i], tree(input[i + 1:]))
 
-def bench_generators(loops: int) -> None:
+def bench_generators(loops: int) -> float:
     assert list(tree(range(10))) == list(range(10))
     range_it = range(loops)
+    iterable = tree(range(100000))
     t0 = pyperf.perf_counter()
     for _ in range_it:
-        for _ in tree(range(100000)):
+        for _ in iterable:
             pass
     return pyperf.perf_counter() - t0
 


### PR DESCRIPTION
- Add a benchmark for coroutines

Benchmark results:

| Benchmark      | 3.10    | 3.12                  |
|----------------|:-------:|:---------------------:|
| coroutines     | 47.1 ms | 34.8 ms: 1.35x faster |
