### PR TITLE
Add `mdp` back into the `default` group

### DIFF
--- a/pyperformance/data-files/benchmarks/MANIFEST
+++ b/pyperformance/data-files/benchmarks/MANIFEST
@@ -73,4 +73,3 @@ xml_etree	<local>
 
 
 [group default]
--mdp


### PR DESCRIPTION
When the `mdp` benchmark was [added](https://github.com/python/pyperformance/pull/14) over 5 years ago, it was disabled by default because it took too long to run (reportedly 7-8 seconds).

However, this situation has improved somewhat (I time about 3 seconds on recent Python versions), and we're currently trying to move towards including more long-running benchmarks in the default suite.

It's a good benchmark, so let's enable it again.