### PR TITLE
Fix bm_raytrace filename option

### DIFF
--- a/pyperformance/data-files/benchmarks/bm_raytrace/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_raytrace/run_benchmark.py
@@ -207,7 +207,7 @@ class Canvas(object):
         header = 'P6 %d %d 255\n' % (self.width, self.height)
         with open(filename, "wb") as fp:
             fp.write(header.encode('ascii'))
-            fp.write(self.bytes.tostring())
+            fp.write(self.bytes.tobytes())
 
 
 def firstIntersection(intersections):


### PR DESCRIPTION
`array.tostring` was replaced with `array.tobytes` by Python 3.2.
`array.tostring` does not work anymore and this feature was broken for many years :(
ref: https://docs.python.org/3/library/array.html#array.array.tobytes