### PR TITLE
Fix installing dev build of pyperformance inside compile/compile_all

### DIFF
--- a/pyperformance/__init__.py
+++ b/pyperformance/__init__.py
@@ -30,14 +30,14 @@ def _is_venv():
 
 
 def _is_devel_install():
-    # pip install <path-to-git-checkout> will do a "devel" install.
+    # pip install -e <path-to-git-checkout> will do a "devel" install.
     # This means it creates a link back to the checkout instead
     # of copying the files.
     try:
         import toml
     except ModuleNotFoundError:
         return False
-    sitepackages = os.path.dirname(toml.__file__)
+    sitepackages = os.path.dirname(os.path.dirname(toml.__file__))
     if os.path.isdir(os.path.join(sitepackages, 'pyperformance')):
         return False
     if not os.path.exists(os.path.join(sitepackages, 'pyperformance.egg-link')):

--- a/pyperformance/compile.py
+++ b/pyperformance/compile.py
@@ -396,7 +396,7 @@ class Python(Task):
         cmd = [self.program, '-u', '-m', 'pip', 'install']
 
         if pyperformance.is_dev():
-            cmd.append(os.path.dirname(pyperformance.PKG_ROOT))
+            cmd.extend(['-e', os.path.dirname(pyperformance.PKG_ROOT)])
         else:
             version = pyperformance.__version__
             cmd.append('pyperformance==%s' % version)


### PR DESCRIPTION
The compile and compile_all commands:

- (a) build a fresh Python and `pip` installs `pyperformance` into it.
- (b) for each benchmark, creates a virtual environment and installs
  `pyperformance` (and other things) into that.

If hacking on a checkout of `pyperformance`, you want to make sure that it's
installing from the local checkout and never from PyPI or your changes won't be
in effect.

There are two bugs related to this one:

- pyperformance detects if it's a dev version by looking for an
  `pyperformance.egg-link` file in `site-packages` [1]. If that's not the case,
  pyperformance is installed from PyPI. In step (a), it installs the local
  `pyperformance` in non-editable mode, thus no `.egg-link` file, so when (b)
  happens, `pyperformance` is installed from PyPI.

- The check for the `.egg-link` file itself is broken, but perhaps because
  `toml` changed from a module to a package at one point. It needs to look up a
  directory.

[1] https://github.com/python/pyperformance/blob/main/pyperformance/__init__.py#L32