### PR TITLE
Fix Manifest Group

### DIFF
--- a/pyperformance/_manifest.py
+++ b/pyperformance/_manifest.py
@@ -95,17 +95,12 @@ class BenchmarksManifest:
 
     @property
     def groups(self):
-        tags = set(self._get_tags())
         names = self._custom_groups()
-        if not names:
-            names = tags
-        else:
-            overwritten = tags & names
-            if overwritten:
-                # XXX
-                raise NotImplementedError(overwritten)
-            names |= tags
         return names | {'all', 'default'}
+
+    @property
+    def tags(self):
+        return set(self._get_tags())
 
     @property
     def filename(self):

--- a/pyperformance/_manifest.py
+++ b/pyperformance/_manifest.py
@@ -220,7 +220,7 @@ class BenchmarksManifest:
             groups = self._resolve_groups()
             benchmarks = groups.get(name)
             if not benchmarks:
-                if name in (set(self._raw_groups) - {'default'}):
+                if name not in self._raw_groups:
                     benchmarks = self._get_tags().get(name, ())
                 elif fail:
                     raise KeyError(name)

--- a/pyperformance/_manifest.py
+++ b/pyperformance/_manifest.py
@@ -145,6 +145,8 @@ class BenchmarksManifest:
     def _add_benchmark(self, spec, metafile, resolve, filename):
         if spec.name in self._raw_groups:
             raise ValueError(f'a group and a benchmark have the same name ({spec.name})')
+        if spec.name == 'all':
+            raise ValueError('a benchmark named "all" is not allowed ("all" is reserved for selecting the full set of declared benchmarks)')
         if metafile:
             if filename:
                 localdir = os.path.dirname(filename)
@@ -164,8 +166,7 @@ class BenchmarksManifest:
         if name in self._byname:
             raise ValueError(f'a group and a benchmark have the same name ({name})')
         if name == 'all':
-            # XXX Emit a warning?
-            return
+            raise ValueError('a group named "all" is not allowed ("all" is reserved for selecting the full set of declared benchmarks)')
         if entries:
             raw = self._raw_groups.get(name)
             if raw is None:

--- a/pyperformance/_manifest.py
+++ b/pyperformance/_manifest.py
@@ -95,9 +95,16 @@ class BenchmarksManifest:
 
     @property
     def groups(self):
+        tags = set(self._get_tags())
         names = self._custom_groups()
         if not names:
-            names = set(self._get_tags())
+            names = tags
+        else:
+            overwritten = tags & names
+            if overwritten:
+                # XXX
+                raise NotImplementedError(overwritten)
+            names |= tags
         return names | {'all', 'default'}
 
     @property

--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -108,6 +108,9 @@ def parse_args():
         'list_groups', help='List benchmark groups of the running Python')
     cmds.append(cmd)
     cmd.add_argument("--manifest", help="benchmark manifest file to use")
+    cmd.add_argument("--tags", action="store_true")
+    cmd.add_argument("--no-tags", dest="tags", action="store_false")
+    cmd.set_defaults(tags=True)
 
     # compile
     cmd = subparsers.add_parser(
@@ -302,7 +305,7 @@ def _main():
         cmd_list(options, benchmarks)
     elif options.action == 'list_groups':
         manifest = _manifest_from_options(options)
-        cmd_list_groups(manifest)
+        cmd_list_groups(manifest, showtags=options.tags)
     else:
         parser.print_help()
         sys.exit(1)

--- a/pyperformance/commands.py
+++ b/pyperformance/commands.py
@@ -28,6 +28,26 @@ def cmd_list_groups(manifest):
             print("- %s" % spec.name)
         print()
 
+    print("=============================")
+    print()
+    print("tags:")
+    print()
+    tags = sorted(manifest.tags or ())
+    if not tags:
+        print("(no tags)")
+    else:
+        for tag in tags:
+            specs = list(manifest.resolve_group(tag))
+            known = set(specs) & all_benchmarks
+            if not known:
+                # skip empty groups
+                continue
+
+            print("%s (%s):" % (tag, len(specs)))
+            for spec in sorted(specs):
+                print("- %s" % spec.name)
+            print()
+
 
 def cmd_venv_create(options, root, python, benchmarks):
     from . import _pythoninfo, _venv

--- a/pyperformance/commands.py
+++ b/pyperformance/commands.py
@@ -11,7 +11,7 @@ def cmd_list(options, benchmarks):
     print("Total: %s benchmarks" % len(benchmarks))
 
 
-def cmd_list_groups(manifest):
+def cmd_list_groups(manifest, *, showtags=True):
     all_benchmarks = set(manifest.benchmarks)
 
     groups = sorted(manifest.groups - {'all', 'default'})
@@ -28,25 +28,26 @@ def cmd_list_groups(manifest):
             print("- %s" % spec.name)
         print()
 
-    print("=============================")
-    print()
-    print("tags:")
-    print()
-    tags = sorted(manifest.tags or ())
-    if not tags:
-        print("(no tags)")
-    else:
-        for tag in tags:
-            specs = list(manifest.resolve_group(tag))
-            known = set(specs) & all_benchmarks
-            if not known:
-                # skip empty groups
-                continue
+    if showtags:
+        print("=============================")
+        print()
+        print("tags:")
+        print()
+        tags = sorted(manifest.tags or ())
+        if not tags:
+            print("(no tags)")
+        else:
+            for tag in tags:
+                specs = list(manifest.resolve_group(tag))
+                known = set(specs) & all_benchmarks
+                if not known:
+                    # skip empty groups
+                    continue
 
-            print("%s (%s):" % (tag, len(specs)))
-            for spec in sorted(specs):
-                print("- %s" % spec.name)
-            print()
+                print("%s (%s):" % (tag, len(specs)))
+                for spec in sorted(specs):
+                    print("- %s" % spec.name)
+                print()
 
 
 def cmd_venv_create(options, root, python, benchmarks):


### PR DESCRIPTION
This addresses several of the problems noted in #234.

Notably:

* disallow groups named "all"
* disallow duplicate group names, even if in different included manifests
* disallow benchmarks named "all"
* disallow duplicate benchmark names
* clean up the "list_groups" command
* fix how group resolution falls back to the tags