### PR TITLE
Fix the django_template benchmark on cpython main

### DIFF
--- a/pyperformance/data-files/benchmarks/bm_django_template/requirements.txt
+++ b/pyperformance/data-files/benchmarks/bm_django_template/requirements.txt
@@ -1,4 +1,5 @@
 asgiref==3.3.4
 django==3.2.4
 pytz==2021.1
+setuptools==65.6.3
 sqlparse==0.4.1

--- a/pyperformance/data-files/benchmarks/bm_sympy/requirements.txt
+++ b/pyperformance/data-files/benchmarks/bm_sympy/requirements.txt
@@ -1,2 +1,3 @@
 mpmath==1.2.1
+setuptools==65.6.3
 sympy==1.8


### PR DESCRIPTION
Fixes #247.

Django has a runtime dependency on distutils, so adding setuptools as a dependency resolves it.

This has already been resolved upstream [1], but this allows us to keep using the same version of Django for the benchmark.

[1] https://github.com/django/django/pull/14240/files