### PR TITLE
Fix manifest parsing

### DIFF
--- a/pyperformance/_manifest.py
+++ b/pyperformance/_manifest.py
@@ -170,14 +170,12 @@ class BenchmarksManifest:
     def _add_group(self, name, entries):
         if name in self._byname:
             raise ValueError(f'a group and a benchmark have the same name ({name})')
-        if name == 'all':
-            raise ValueError('a group named "all" is not allowed ("all" is reserved for selecting the full set of declared benchmarks)')
         if entries is None:
             if name in self._raw_groups:
                 return
             self._raw_groups[name] = None
         elif name in self._raw_groups and self._raw_groups[name] is not None:
-            raise ValueError(f'a group named {name} was already defined')
+            self._raw_groups[name].extend(list(entries) if entries else [])
         else:
             self._raw_groups[name] = list(entries) if entries else []
         self._groups = None  # Force re-resolution.


### PR DESCRIPTION

I'm a little unclear about how the manifest parsing is supposed to work, so I'm not sure this is the correct solution.

To reproduce the bug, use a "meta" manifest file that loads both the pyperformance suite and the pyston python-macrobenchmarks suite (as we do in our infra for the faster-cpython project):

```
[includes]
<default>
~benchmarking/BENCH/repositories/pyston-benchmarks/benchmarks/MANIFEST
```

There seems to be two bugs:

Both pyperformance and pyston have an empty `[group default]` entry.  I'm not 100% sure what that is supposed to do in practice, but it causes the "a group named default was already defined" error to raise.  Here, I just make the groups concatenate instead.

The pyston manifest has:

```
[group all]
-json
```

It seems like this *should* be valid, but the code here disallows any mention of `all`.

Again, I have no idea if this fix is correct, but it does at least let these two suites of benchmarks combine correctly.