### PR TITLE
Fix parameter

### DIFF
--- a/pyperformance/_benchmark.py
+++ b/pyperformance/_benchmark.py
@@ -214,7 +214,7 @@ def _run_perf_script(python, runscript, runid, *,
             '--output', tmp,
         ]
         if pyperf_opts and '--copy-env' in pyperf_opts:
-            argv, env = _prep_cmd(python, runscript, opts, runid, NOOP)
+            argv, env = _prep_cmd(python, runscript, opts, runid)
         else:
             opts, inherit_envvar = _resolve_restricted_opts(opts)
             argv, env = _prep_cmd(python, runscript, opts, runid, inherit_envvar)


### PR DESCRIPTION
An undefined variable is used as a parameter, which looks like it should be wrong.