### PR TITLE
Skip 3.12-dev pending Greenlet support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         # Test all supported versions on Ubuntu:
         os: [ubuntu-latest]
         # Skip 3.12-dev, pending https://github.com/python-greenlet/greenlet/issues/323
-        python: [pypy3.7, pypy3.8, pypy3.9, "3.7", "3.8", "3.9", "3.10", 3.11-dev]
+        python: [pypy3.8, pypy3.9, "3.7", "3.8", "3.9", "3.10", 3.11-dev]
         include:
           # Also test macOS and Windows:
           - os: macos-latest


### PR DESCRIPTION
At the moment the `3.12-dev` builds are failing, causing every build to show as failed.

It's failing because Greenlet doesn't yet support 3.12. The tracking issue is at https://github.com/python-greenlet/greenlet/issues/323 and there's a PR at https://github.com/python-greenlet/greenlet/pull/327 but it's not ready yet.

In the meantime, we can mark `3.12-dev` as "experimental", so whilst the individual job still fails, it doesn't mark the whole build as failed.

Docs: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error

---

Also bump GitHub Actions, allow building feature branches, and we can fold the PyPy config into the main list. `workflow_dispatch` adds a button to the UI to be able to trigger new builds, occasionally useful.

---

Shall we also remove `pypy3.7`? The newest PyPy only supports 3.8 and 3.9:

* https://www.pypy.org/posts/2022/12/pypy-v7311-release.html