### PR TITLE
Skip tests failing on Python 3.12 pending greenlet support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,12 +2,11 @@ name: test
 
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
   schedule:
     # Midnight UTC:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
 
@@ -33,14 +32,14 @@ jobs:
           - os: windows-latest
             python: "3.10"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: "!endsWith(matrix.python, '-dev')"
       with:
         python-version: ${{ matrix.python }}
     - name: Set up Python ${{ matrix.python }} using deadsnakes
-      uses: deadsnakes/action@v2.1.1
+      uses: deadsnakes/action@v3.0.0
       if: "endsWith(matrix.python, '-dev')"
       with:
         python-version: ${{ matrix.python }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # Test all supported versions on Ubuntu:
         os: [ubuntu-latest]
-        python: [pypy3.7, pypy3.8, pypy3.9, "3.7", "3.8", "3.9", "3.10", 3.11-dev, 3.12-dev]
+        python: [pypy3.8, pypy3.9, "3.7", "3.8", "3.9", "3.10", 3.11-dev, 3.12-dev]
         include:
           # Also test macOS and Windows:
           - os: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,15 +18,9 @@ jobs:
       matrix:
         # Test all supported versions on Ubuntu:
         os: [ubuntu-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", 3.11-dev, 3.12-dev]
+        python: [pypy3.7, pypy3.8, pypy3.9, "3.7", "3.8", "3.9", "3.10", 3.11-dev, 3.12-dev]
         include:
-          # Also test PyPy, macOS, and Windows:
-          - os: ubuntu-latest
-            python: pypy-3.9
-          - os: ubuntu-latest
-            python: pypy-3.8
-          - os: ubuntu-latest
-            python: pypy-3.7
+          # Also test macOS and Windows:
           - os: macos-latest
             python: "3.10"
           - os: windows-latest

--- a/pyperformance/tests/test_commands.py
+++ b/pyperformance/tests/test_commands.py
@@ -7,6 +7,13 @@ import unittest
 import pyperformance
 from pyperformance import tests
 
+# Skip tests failing on Python 3.12
+# pending https://github.com/python-greenlet/greenlet/issues/323
+try:
+    import greenlet
+except ImportError:
+    greenlet = None
+
 
 class FullStackTests(tests.Functional, unittest.TestCase):
 
@@ -92,6 +99,7 @@ class FullStackTests(tests.Functional, unittest.TestCase):
     ###################################
     # venv
 
+    @unittest.skipUnless(greenlet, "requires greenlet")
     def test_venv(self):
         # XXX Capture and check the output.
         root = self.resolve_tmp('venv', unique=True)
@@ -140,6 +148,7 @@ class FullStackTests(tests.Functional, unittest.TestCase):
     ###################################
     # run
 
+    @unittest.skipUnless(greenlet, "requires greenlet")
     def test_run_and_show(self):
         filename = self.resolve_tmp('bench.json')
 


### PR DESCRIPTION
Fixes #263.

Alternative to and closes https://github.com/python/pyperformance/pull/259.

At the moment the `3.12-dev` builds are failing, causing every build to show as failed.

It's failing because greenlet doesn't yet support 3.12. The tracking issue is at https://github.com/python-greenlet/greenlet/issues/323 and there's a PR at https://github.com/python-greenlet/greenlet/pull/327 but it's not ready yet.

In the meantime, let's skip the two tests when greenlet isn't available.

---

Also bump GitHub Actions, allow building feature branches, and we can fold the PyPy config into the main list. `workflow_dispatch` adds a button to the UI to be able to trigger new builds, occasionally useful.

And remove `pypy3.7`, the newest PyPy only supports 3.8 and 3.9:

* https://www.pypy.org/posts/2022/12/pypy-v7311-release.html