### PR TITLE
Fix undefined variable

### DIFF
--- a/pyperformance/_venv.py
+++ b/pyperformance/_venv.py
@@ -215,9 +215,9 @@ class VirtualEnvironment:
             upgrade=upgrade,
         )
         if ec != 0:
-            raise VenvPipInstallFailedError(root, ec)
+            raise VenvPipInstallFailedError(self.root, ec)
         elif not _pip.is_pip_installed(self.python, env=self._env):
-            raise VenvPipInstallFailedError(root, 0, "pip doesn't work")
+            raise VenvPipInstallFailedError(self.root, 0, "pip doesn't work")
 
         if installer:
             # Upgrade installer dependencies (setuptools, ...)


### PR DESCRIPTION
NameError: name 'root' is not defined: parameter `root` of `VenvPipInstallFailedError()` is undefined, it should be `self.root`. 

NameError before changed `root` to `self.root`
```bash
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/pyperformance/__main__.py", line 2, in <module>
    pyperformance.cli.main()
  File "/home/ubuntu/.local/lib/python3.10/site-packages/pyperformance/cli.py", line 317, in main
    _main()
  File "/home/ubuntu/.local/lib/python3.10/site-packages/pyperformance/cli.py", line 301, in _main
    cmd_run(options, benchmarks)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/pyperformance/commands.py", line 180, in cmd_run
    suite, errors = run_benchmarks(benchmarks, executable, options)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/pyperformance/run.py", line 61, in run_benchmarks
    common = VenvForBenchmarks.ensure(
  File "/home/ubuntu/.local/lib/python3.10/site-packages/pyperformance/venv.py", line 193, in ensure
    return cls.create(
  File "/home/ubuntu/.local/lib/python3.10/site-packages/pyperformance/venv.py", line 162, in create
    self.ensure_pip(upgrade=upgrade)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/pyperformance/_venv.py", line 220, in ensure_pip
    raise VenvPipInstallFailedError(root, ec)
NameError: name 'root' is not defined
```
After changed `root` to `self.root`:
```bash
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/pyperformance/__main__.py", line 2, in <module>
    pyperformance.cli.main()
  File "/home/ubuntu/.local/lib/python3.10/site-packages/pyperformance/cli.py", line 317, in main
    _main()
  File "/home/ubuntu/.local/lib/python3.10/site-packages/pyperformance/cli.py", line 301, in _main
    cmd_run(options, benchmarks)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/pyperformance/commands.py", line 180, in cmd_run
    suite, errors = run_benchmarks(benchmarks, executable, options)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/pyperformance/run.py", line 61, in run_benchmarks
    common = VenvForBenchmarks.ensure(
  File "/home/ubuntu/.local/lib/python3.10/site-packages/pyperformance/venv.py", line 193, in ensure
    return cls.create(
  File "/home/ubuntu/.local/lib/python3.10/site-packages/pyperformance/venv.py", line 162, in create
    self.ensure_pip(upgrade=upgrade)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/pyperformance/_venv.py", line 220, in ensure_pip
    raise VenvPipInstallFailedError(self.root, ec)
pyperformance._venv.VenvPipInstallFailedError: failed to install pip in venv /home/ubuntu/pyperformance/venv/cpython3.11-f90a0555cbd0-compat-07e19f9c3993
```