### PR TITLE
gh-263: Remove detection bit for a while

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,15 +69,3 @@ jobs:
       id: pyperformance
       run: python -u -m pyperformance.tests
       continue-on-error: ${{ matrix.experimental }}
-    - name: Notify result for experimental tasks (Failure)
-      uses: marocchino/sticky-pull-request-comment@v2
-      if: ${{ steps.pyperformance.outcome != 'success' && matrix.experimental }}
-      with:
-        message: |
-          ❌: ${{ matrix.os }} - ${{ matrix.python }} has failed, but allowed as the experimental task.
-    - name: Notify result for experimental tasks (Success)
-      uses: marocchino/sticky-pull-request-comment@v2
-      if: ${{ steps.pyperformance.outcome == 'success' && matrix.experimental }}
-      with:
-        message: |
-          ✅: ${{ matrix.os }} - ${{ matrix.python }} has passed, now we can disable the experimental flag.


### PR DESCRIPTION
Until the `Resource not accessible by integration` is resolved, let's opt-out of the detection bit.