### PR TITLE
Extend async tree benchmarks to cover eager task execution

### DIFF
--- a/doc/benchmarks.rst
+++ b/doc/benchmarks.rst
@@ -66,11 +66,14 @@ Async workload benchmark, which calls ``asyncio.gather()`` on a tree (6 levels d
 
 * ``async_tree``: no actual async work at any leaf node.
 * ``async_tree_io``: all leaf nodes simulate async IO workload (async sleep 50ms).
-* ``async_tree_memoization``: all leaf nodes simulate async IO workload with 90% of 
+* ``async_tree_memoization``: all leaf nodes simulate async IO workload with 90% of
   the data memoized.
 * ``async_tree_cpu_io_mixed``: half of the leaf nodes simulate CPU-bound workload
-  (``math.factorial(500)``) and the other half simulate the same workload as the 
+  (``math.factorial(500)``) and the other half simulate the same workload as the
   ``async_tree_memoization`` variant.
+
+These benchmarks also have an "eager" flavor that uses asyncio eager task factory,
+if available.
 
 
 chameleon

--- a/pyperformance/data-files/benchmarks/MANIFEST
+++ b/pyperformance/data-files/benchmarks/MANIFEST
@@ -7,6 +7,10 @@ async_tree	<local>
 async_tree_cpu_io_mixed	<local:async_tree>
 async_tree_io	<local:async_tree>
 async_tree_memoization	<local:async_tree>
+async_tree_eager	<local:async_tree>
+async_tree_eager_cpu_io_mixed	<local:async_tree>
+async_tree_eager_io	<local:async_tree>
+async_tree_eager_memoization	<local:async_tree>
 asyncio_tcp	<local>
 asyncio_tcp_ssl	<local:asyncio_tcp>
 concurrent_imap	<local>

--- a/pyperformance/data-files/benchmarks/bm_async_tree/bm_async_tree_cpu_io_mixed.toml
+++ b/pyperformance/data-files/benchmarks/bm_async_tree/bm_async_tree_cpu_io_mixed.toml
@@ -1,4 +1,3 @@
 [tool.pyperformance]
 name = "async_tree_cpu_io_mixed"
 extra_opts = ["cpu_io_mixed"]
-

--- a/pyperformance/data-files/benchmarks/bm_async_tree/bm_async_tree_eager.toml
+++ b/pyperformance/data-files/benchmarks/bm_async_tree/bm_async_tree_eager.toml
@@ -1,0 +1,3 @@
+[tool.pyperformance]
+name = "async_tree_eager"
+extra_opts = ["eager"]

--- a/pyperformance/data-files/benchmarks/bm_async_tree/bm_async_tree_eager_cpu_io_mixed.toml
+++ b/pyperformance/data-files/benchmarks/bm_async_tree/bm_async_tree_eager_cpu_io_mixed.toml
@@ -1,0 +1,3 @@
+[tool.pyperformance]
+name = "async_tree_eager_cpu_io_mixed"
+extra_opts = ["eager_cpu_io_mixed"]

--- a/pyperformance/data-files/benchmarks/bm_async_tree/bm_async_tree_eager_io.toml
+++ b/pyperformance/data-files/benchmarks/bm_async_tree/bm_async_tree_eager_io.toml
@@ -1,0 +1,3 @@
+[tool.pyperformance]
+name = "async_tree_eager_io"
+extra_opts = ["eager_io"]

--- a/pyperformance/data-files/benchmarks/bm_async_tree/bm_async_tree_eager_memoization.toml
+++ b/pyperformance/data-files/benchmarks/bm_async_tree/bm_async_tree_eager_memoization.toml
@@ -1,0 +1,3 @@
+[tool.pyperformance]
+name = "async_tree_eager_memoization"
+extra_opts = ["eager_memoization"]

--- a/pyperformance/data-files/benchmarks/bm_async_tree/bm_async_tree_io.toml
+++ b/pyperformance/data-files/benchmarks/bm_async_tree/bm_async_tree_io.toml
@@ -1,4 +1,3 @@
 [tool.pyperformance]
 name = "async_tree_io"
 extra_opts = ["io"]
-

--- a/pyperformance/data-files/benchmarks/bm_async_tree/bm_async_tree_memoization.toml
+++ b/pyperformance/data-files/benchmarks/bm_async_tree/bm_async_tree_memoization.toml
@@ -1,4 +1,3 @@
 [tool.pyperformance]
 name = "async_tree_memoization"
 extra_opts = ["memoization"]
-

--- a/pyperformance/data-files/benchmarks/bm_async_tree/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_async_tree/run_benchmark.py
@@ -62,7 +62,7 @@ class AsyncTree:
 
 class EagerMixin:
     async def run(self):
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         if hasattr(asyncio, 'eager_task_factory'):
             loop.set_task_factory(asyncio.eager_task_factory)
         return await super().run()


### PR DESCRIPTION
goes along with https://github.com/python/cpython/issues/97696 (implemented in https://github.com/python/cpython/pull/102853)

this change to pyperformance was used to measure the impact of the eager task execution feature.