### PR TITLE
Don't run the daily test on contributors' GitHub forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       pull-requests: write
     name: ${{ matrix.os }} - ${{ matrix.python }}
+    if: ${{ github.repository == 'python/pyperformance' || github.event_name != 'schedule' || github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       pull-requests: write
     name: ${{ matrix.os }} - ${{ matrix.python }}
-    if: ${{ github.event_name != 'schedule' || (github.repository == 'python/pyperformance' || && github.event_name == 'schedule') }}
+    if: ${{ github.event_name != 'schedule' || (github.repository == 'python/pyperformance' && github.event_name == 'schedule') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       pull-requests: write
     name: ${{ matrix.os }} - ${{ matrix.python }}
-    if: ${{ github.repository == 'python/pyperformance' || github.event_name != 'schedule' || github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'schedule' || (github.repository == 'python/pyperformance' || && github.event_name == 'schedule') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
I'm currently getting a daily email informing me that the pyperformance tests failed on the `AlexWaygood/pyperformance` repo (because I enabled workflows for my fork). This PR makes it so that the `test` workflow only happens on `python/pyperformance`, not on contributors' forks of the repo (unless they specifically request the workflow by manually triggering the workflow or by making a PR to their fork).

We use a condition like this in our typeshed workflow here, and it works great: https://github.com/python/typeshed/blob/ae0c9f9dadd72ee823d289416943a9109e24fe52/.github/workflows/daily.yml#L33