### PR TITLE
Add mypy config; run mypy in CI

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,29 @@
+name: mypy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: 1
+  TERM: xterm-256color # needed for FORCE_COLOR to work on mypy on Ubuntu, see https://github.com/python/mypy/issues/13817
+
+jobs:
+  mypy:
+    name: Check code with mypy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          cache: "pip"
+          cache-dependency-path: "pyproject.toml"
+          python-version: "3.11"
+      - run: pip install -e .[dev]
+      - run: pip freeze --all
+      - run: mypy

--- a/pyperformance/_benchmark.py
+++ b/pyperformance/_benchmark.py
@@ -182,7 +182,7 @@ class Benchmark:
             python = venv.python
 
         if not runid:
-            from ..run import get_run_id
+            from .run import get_run_id
             runid = get_run_id(python, self)
 
         runscript = self.runscript

--- a/pyperformance/_pyproject_toml.py
+++ b/pyperformance/_pyproject_toml.py
@@ -20,7 +20,7 @@ import packaging.utils
 import packaging.version
 
 try:
-    import tomllib
+    import tomllib  # type: ignore[import] # tomllib doesn't exist on 3.7-3.10
 except ImportError:
     import tomli as tomllib
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     'tox',
+    'mypy==1.2.0',
+    'tomli',  # Needed even on 3.11+ for typechecking with mypy
 ]
 
 [project.scripts]
@@ -81,3 +83,23 @@ find = {}  # Scanning implicit namespaces is active by default
 
 [tool.setuptools.dynamic]
 version = {attr = "pyperformance.__version__"}
+
+[tool.mypy]
+python_version = "3.7"
+pretty = true
+enable_error_code = "ignore-without-code"
+disallow_any_generics = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_unused_configs = true
+files = [
+    'pyperformance/',
+]
+exclude = [
+    'pyperformance/data-files/',
+    'pyperformance/tests/'
+]
+
+[[tool.mypy.overrides]]
+module = "pyperf"
+ignore_missing_imports = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3, pypy3, doc, pep8
+envlist = py3, pypy3, doc, pep8, mypy
 isolated_build = True
 
 [testenv]
@@ -27,3 +27,10 @@ commands = flake8 pyperformance runtests.py setup.py
 # E741 ambiguous variable name 'l' (don't modify benhcmarks just for that)
 # W503 line break before binary operator
 ignore = E501,E741,W503
+
+[testenv:mypy]
+basepython = python3
+deps=
+    mypy
+    tomli
+commands = mypy


### PR DESCRIPTION
Work towards #282.

Adding type hints without validating them with a type checker is a bad idea, because the type hints can quickly go out of date with the source code they're describing. This PR adds some configuration for mypy, and a job to run mypy in CI.

Mypy is run on the `pyperformance/` directory, but `pyperformance/data-files/` and `pyperformance/tests/` are excluded from being typechecked. I've only enabled a few of the stricter settings for now, so that we can take advantage of "gradual typing" -- mypy will only emit errors on functions that have type annotations. It will assume all functions that don't have type annotations are meant to be ignored by the type checker.