### PR TITLE
Include cert files for asyncio_tcp_ssl benchmark

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,5 +15,6 @@ include pyperformance/data-files/benchmarks/MANIFEST
 include pyperformance/data-files/benchmarks/bm_*/*.toml
 include pyperformance/data-files/benchmarks/bm_*/*.py
 include pyperformance/data-files/benchmarks/bm_*/requirements.txt
+include pyperformance/data-files/benchmarks/bm_*/*.pem
 recursive-include pyperformance/data-files/benchmarks/bm_*/data *
 recursive-exclude pyperformance/tests *


### PR DESCRIPTION
The `asyncio_tcp_ssl` benchmark currently fails when it's run on an installed pyperformance, because the cert files it depends on are not installed.

This updates the `MANIFEST.in` so they are installed.

```
2023-05-07T01:58:11.2528043Z   File "/home/benchmarking/actions-runner/_work/benchmarking/benchmarking/cpython/Lib/asyncio/runners.py", line 194, in run
2023-05-07T01:58:11.2528559Z     return runner.run(main)
2023-05-07T01:58:11.2528859Z            ^^^^^^^^^^^^^^^^
2023-05-07T01:58:11.2529594Z   File "/home/benchmarking/actions-runner/_work/benchmarking/benchmarking/cpython/Lib/asyncio/runners.py", line 118, in run
2023-05-07T01:58:11.2530148Z     return self._loop.run_until_complete(task)
2023-05-07T01:58:11.2530507Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-05-07T01:58:11.2531328Z   File "/home/benchmarking/actions-runner/_work/benchmarking/benchmarking/cpython/Lib/asyncio/base_events.py", line 664, in run_until_complete
2023-05-07T01:58:11.2531875Z     return future.result()
2023-05-07T01:58:11.2532172Z            ^^^^^^^^^^^^^^^
2023-05-07T01:58:11.2533318Z   File "/home/benchmarking/actions-runner/_work/benchmarking/benchmarking/venv/cpython3.12-42c7efcc310b-compat-07e19f9c3993/lib/python3.12/site-packages/pyperf/_runner.py", line 580, in main
2023-05-07T01:58:11.2533980Z     await local_func()
2023-05-07T01:58:11.2534965Z   File "/home/benchmarking/actions-runner/_work/benchmarking/benchmarking/venv/lib/python3.12/site-packages/pyperformance/data-files/benchmarks/bm_asyncio_tcp/run_benchmark.py", line 33, in main
2023-05-07T01:58:11.2535666Z     server_context.load_cert_chain(SSL_CERT, SSL_KEY)
2023-05-07T01:58:11.2536113Z FileNotFoundError: [Errno 2] No such file or directory
```