### PR TITLE
Don't specify setuptools as a dependency

### DIFF
--- a/pyperformance/data-files/benchmarks/bm_django_template/requirements.txt
+++ b/pyperformance/data-files/benchmarks/bm_django_template/requirements.txt
@@ -1,5 +1,4 @@
 asgiref==3.3.4
 django==3.2.4
 pytz==2021.1
-setuptools==65.6.3
 sqlparse==0.4.1

--- a/pyperformance/data-files/benchmarks/bm_sympy/requirements.txt
+++ b/pyperformance/data-files/benchmarks/bm_sympy/requirements.txt
@@ -1,3 +1,2 @@
 mpmath==1.2.1
-setuptools==65.6.3
 sympy==1.8


### PR DESCRIPTION
pyperformance will always install setuptools anyway, and specifying the version here installs a version that is too old and breaks on current Python 3.12