### PR TITLE
Set a dependabot schedule interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,3 +2,5 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/pyperformance/requirements"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Follow on from https://github.com/python/pyperformance/pull/296, we need to set a `schedule.interval`:

https://github.com/python/pyperformance/pull/296#issuecomment-1571564661

Monthly works well in our other repos:

```console
❯ rg "  interval: " -t yaml
output/python/bedevere/.github/dependabot.yml
7:      interval: monthly
16:      interval: monthly

output/python/miss-islington/.github/dependabot.yml
6:    interval: monthly
14:    interval: monthly

output/python/cpython/.github/dependabot.yml
6:      interval: "monthly"

output/python/blurb_it/.github/dependabot.yml
6:    interval: monthly

output/python/devguide/.github/dependabot.yml
6:    interval: monthly

output/python/cherry-picker/.github/dependabot.yml
6:    interval: monthly
```