### PR TITLE
Revert "Bump tornado from 6.1 to 6.3.2 in /pyperformance/data-files/benchmarks/bm_tornado_http"

### DIFF
--- a/pyperformance/data-files/benchmarks/bm_tornado_http/requirements.txt
+++ b/pyperformance/data-files/benchmarks/bm_tornado_http/requirements.txt
@@ -1,1 +1,1 @@
-tornado==6.3.2
+tornado==6.1


### PR DESCRIPTION
Reverts python/pyperformance#297

Apologies, I should't have merged https://github.com/python/pyperformance/pull/297 because we only want to bump the non-benchmark dependencies:

* https://github.com/python/pyperformance/pull/296
* https://github.com/python/pyperformance/issues/223