### PR TITLE
Publish to PyPI using a trusted publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -27,6 +31,3 @@ jobs:
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This means we don't need a long-lived token stored in this repo:

* https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
* https://docs.pypi.org/trusted-publishers/using-a-publisher/

Needs an admin to log in to https://pypi.org/manage/project/pyperformance/settings/publishing/ and add a new publisher:

<img src=https://github.com/python/pyperformance/assets/1324225/fda485db-58bc-4412-8693-2885c8664f6f width=40%>


After that, we can delete `PYPI_API_TOKEN` from this repo's secrets and also the corresponding one at https://pypi.org/manage/account/ for whoever set it up.
