### PR TITLE
Expose --min-time from pyperf to pyperformance CLI

### DIFF
--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -72,6 +72,9 @@ def parse_args():
     cmd.add_argument("--append", metavar="FILENAME",
                      help="Add runs to an existing file, or create it "
                      "if it doesn't exist")
+    cmd.add_argument("--min-time", metavar="MIN_TIME",
+                     help="Minimum duration in seconds of a single "
+                     "value, used to calibrate the number of loops")
     filter_opts(cmd)
 
     # show

--- a/pyperformance/run.py
+++ b/pyperformance/run.py
@@ -206,5 +206,7 @@ def get_pyperf_opts(options):
         opts.append('--track-memory')
     if options.inherit_environ:
         opts.append('--inherit-environ=%s' % ','.join(options.inherit_environ))
+    if options.min_time:
+        opts.append('--min-time=%s' % options.min_time)
 
     return opts


### PR DESCRIPTION
The user can now control the minimum time a benchmark should run directly from the CLI via --min-time which then is passed to pyperf.