### PR TITLE
Bump coverage to 7.3.2 for compatibility with Python 3.13

### DIFF
--- a/pyperformance/data-files/benchmarks/bm_coverage/requirements.txt
+++ b/pyperformance/data-files/benchmarks/bm_coverage/requirements.txt
@@ -1,1 +1,1 @@
-coverage==6.4.1
+coverage==7.3.2


### PR DESCRIPTION
In https://discuss.python.org/t/about-speed-python-org-and-aarch64/22519/9?u=hugovk, @diegorusso discovered coverage.py 6.4.1 and 7.3.1 fail to build its ctracer for Python 3.13, meaning it uses the Python version instead of the C version, which is much slower.

However, coverage.py 7.3.2 works for Python 3.13.

---

What's the policy around bumping dependencies of benchmarks?

Do we minimise them to keep results stable?

In this case, it seems necessary to update.