### PR TITLE
Add experimental CI for CPython 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         # Test all supported versions on Ubuntu:
         os: [ubuntu-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         experimental: [false]
         include:
           # As the experimental task for the dev version.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,19 +32,19 @@ jobs:
             experimental: true
           # Also test PyPy, macOS, and Windows:
           - os: ubuntu-latest
+            python: pypy-3.10
+            experimental: false
+          - os: ubuntu-latest
             python: pypy-3.9
             experimental: false
           - os: ubuntu-latest
             python: pypy-3.8
             experimental: false
-          - os: ubuntu-latest
-            python: pypy-3.7
-            experimental: false
           - os: macos-latest
-            python: "3.10"
+            python: "3.11"
             experimental: false
           - os: windows-latest
-            python: "3.10"
+            python: "3.11"
             experimental: false
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,10 +39,10 @@ jobs:
             experimental: false
           - os: macos-latest
             python: "3.12"
-            experimental: false
+            experimental: true
           - os: windows-latest
             python: "3.12"
-            experimental: false
+            experimental: true
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,6 @@ jobs:
           - os: ubuntu-latest
             python: pypy-3.9
             experimental: false
-          - os: ubuntu-latest
-            python: pypy-3.8
-            experimental: false
           - os: macos-latest
             python: "3.12"
             experimental: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,10 +41,10 @@ jobs:
             python: pypy-3.8
             experimental: false
           - os: macos-latest
-            python: "3.11"
+            python: "3.12"
             experimental: false
           - os: windows-latest
-            python: "3.11"
+            python: "3.12"
             experimental: false
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,12 +23,12 @@ jobs:
       matrix:
         # Test all supported versions on Ubuntu:
         os: [ubuntu-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         experimental: [false]
         include:
           # As the experimental task for the dev version.
           - os: ubuntu-latest
-            python: "3.12-dev"
+            python: "3.13-dev"
             experimental: true
           # Also test PyPy, macOS, and Windows:
           - os: ubuntu-latest

--- a/pyperformance/data-files/benchmarks/bm_sqlalchemy_declarative/requirements.txt
+++ b/pyperformance/data-files/benchmarks/bm_sqlalchemy_declarative/requirements.txt
@@ -1,2 +1,2 @@
-greenlet==2.0.0a2
+greenlet==3.0.0rc3
 sqlalchemy==1.4.19

--- a/pyperformance/data-files/benchmarks/bm_sqlalchemy_imperative/requirements.txt
+++ b/pyperformance/data-files/benchmarks/bm_sqlalchemy_imperative/requirements.txt
@@ -1,2 +1,2 @@
-greenlet==2.0.0a2
+greenlet==3.0.0rc3
 sqlalchemy==1.4.19


### PR DESCRIPTION
* Add CPython 3.13 as the experimental CI
* Upgrade greenlet to 3.0.0-rc3
* Update CPython 3.12 as the non-experimental CI
* Remove Python 3.7 from the CI (EOL)
* Set 3.12 default CPython version for other platforms