### PR TITLE
Upgrade to pyperf 2.6.2

### DIFF
--- a/pyperformance/requirements/requirements.txt
+++ b/pyperformance/requirements/requirements.txt
@@ -10,5 +10,5 @@ psutil==5.9.5
     # via
     #   -r requirements.in
     #   pyperf
-pyperf==2.6.1
+pyperf==2.6.2
     # via -r requirements.in


### PR DESCRIPTION
This is to get [this bugfix](https://github.com/psf/pyperf/pull/170), that pystats weren't collected during warmups, and therefore we were missing some stats about specializations and optimizations.