### PR TITLE
Fix the django_template benchmark

### DIFF
--- a/pyperformance/data-files/benchmarks/bm_django_template/pyproject.toml
+++ b/pyperformance/data-files/benchmarks/bm_django_template/pyproject.toml
@@ -4,6 +4,7 @@ requires-python = ">=3.8"
 dependencies = [
     "pyperf",
     "django",
+    "legacy-cgi",
 ]
 urls = {repository = "https://github.com/python/pyperformance"}
 dynamic = ["version"]

--- a/pyperformance/data-files/benchmarks/bm_django_template/requirements.txt
+++ b/pyperformance/data-files/benchmarks/bm_django_template/requirements.txt
@@ -2,3 +2,4 @@ asgiref==3.3.4
 django==3.2.4
 pytz==2021.1
 sqlparse==0.4.1
+legacy-cgi==2.6


### PR DESCRIPTION
This is broken by the removal of the `cgi` module in Python 3.13.  This adds the `legacy-cgi` PyPI library as a dependency as a workaround.