### PR TITLE
Upgrade to pyperf 2.6.3

### DIFF
--- a/pyperformance/requirements/requirements.txt
+++ b/pyperformance/requirements/requirements.txt
@@ -10,5 +10,5 @@ psutil==5.9.5
     # via
     #   -r requirements.in
     #   pyperf
-pyperf==2.6.2
+pyperf==2.6.3
     # via -r requirements.in


### PR DESCRIPTION
See: https://github.com/python/cpython/issues/116024

Except for coverge.py related benchmarks, pyperformance is runnable from a free-threaded build.
cc @colesbury 