### PR TITLE
Skip dask benchmark on Windows for Python 3.13

### DIFF
--- a/pyperformance/data-files/benchmarks/bm_dask/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_dask/run_benchmark.py
@@ -4,7 +4,10 @@ Benchmark the Dask scheduler running a large number of simple jobs.
 Author: Matt Rocklin, Michael Droettboom
 """
 
+import sys
+
 from dask.distributed import Client, Worker, Scheduler, wait
+from dask import distributed
 
 import pyperf
 
@@ -26,6 +29,9 @@ async def benchmark():
 
 
 if __name__ == "__main__":
+    if distributed.__version__ <= "2024.5.0" and sys.version_info >= (3, 13) and sys.platform == "win32":
+        raise RuntimeError("Benchmark doesn't work with Python 3.13 on Windows")
+
     runner = pyperf.Runner()
     runner.metadata['description'] = "Benchmark dask"
     runner.bench_async_func('dask', benchmark)


### PR DESCRIPTION
The [dask benchmark hangs indefinitely on Python 3.13 on Windows](https://github.com/python/cpython/issues/118715).  This will just raise an exception instead to fix the benchmark.

There is already [a fix for this bug in dask here](https://github.com/dask/distributed/commit/e4a054505f1d584d920d6d1df2c419074de45d05), however, until that is released, we should guard against it so the benchmark suite doesn't hang on Windows.