### PR TITLE
Add benchmarks for the decimal module

### DIFF
--- a/pyperformance/data-files/benchmarks/bm_decimal_factorial/pyproject.toml
+++ b/pyperformance/data-files/benchmarks/bm_decimal_factorial/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "pyperformance_bm_decimal_factorial"
+requires-python = ">=3.8"
+dependencies = ["pyperf"]
+urls = {repository = "https://github.com/python/pyperformance"}
+dynamic = ["version"]
+
+[tool.pyperformance]
+name = "decimal_factorial"
+tags = "decimal"

--- a/pyperformance/data-files/benchmarks/bm_decimal_factorial/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_decimal_factorial/run_benchmark.py
@@ -1,0 +1,50 @@
+"""
+Calculate `factorial` using the decimal module.
+
+- 2024-06-14: Michael Droettboom copied this from
+  Modules/_decimal/tests/bench.py in the CPython source and adapted to use
+  pyperf.
+"""
+
+# Original copyright notice in CPython source:
+
+#
+# Copyright (C) 2001-2012 Python Software Foundation. All Rights Reserved.
+# Modified and extended by Stefan Krah.
+#
+
+
+import decimal
+
+
+import pyperf
+
+
+def factorial(n, m):
+    if n > m:
+        return factorial(m, n)
+    elif m == 0:
+        return 1
+    elif n == m:
+        return n
+    else:
+        return factorial(n, (n + m) // 2) * factorial((n + m) // 2 + 1, m)
+
+
+def bench_decimal_factorial():
+    c = decimal.getcontext()
+    c.prec = decimal.MAX_PREC
+    c.Emax = decimal.MAX_EMAX
+    c.Emin = decimal.MIN_EMIN
+
+    for n in [10000, 100000]:
+        # C version of decimal
+        _ = factorial(decimal.Decimal(n), 0)
+
+
+if __name__ == "__main__":
+    runner = pyperf.Runner()
+    runner.metadata["description"] = "decimal_factorial benchmark"
+
+    args = runner.parse_args()
+    runner.bench_func("decimal_factorial", bench_decimal_factorial)

--- a/pyperformance/data-files/benchmarks/bm_decimal_pi/pyproject.toml
+++ b/pyperformance/data-files/benchmarks/bm_decimal_pi/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "pyperformance_bm_decimal_pi"
+requires-python = ">=3.8"
+dependencies = ["pyperf"]
+urls = {repository = "https://github.com/python/pyperformance"}
+dynamic = ["version"]
+
+[tool.pyperformance]
+name = "decimal_pi"
+tags = "decimal"

--- a/pyperformance/data-files/benchmarks/bm_decimal_pi/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_decimal_pi/run_benchmark.py
@@ -1,0 +1,50 @@
+"""
+Calculate `pi` using the decimal module.
+
+The `pidigits` benchmark does a similar thing using regular (long) ints.
+
+- 2024-06-14: Michael Droettboom copied this from
+  Modules/_decimal/tests/bench.py in the CPython source and adapted to use
+  pyperf.
+"""
+
+# Original copyright notice in CPython source:
+
+#
+# Copyright (C) 2001-2012 Python Software Foundation. All Rights Reserved.
+# Modified and extended by Stefan Krah.
+#
+
+
+import decimal
+
+
+import pyperf
+
+
+def pi_decimal():
+    """decimal"""
+    D = decimal.Decimal
+    lasts, t, s, n, na, d, da = D(0), D(3), D(3), D(1), D(0), D(0), D(24)
+    while s != lasts:
+        lasts = s
+        n, na = n + na, na + 8
+        d, da = d + da, da + 32
+        t = (t * n) / d
+        s += t
+    return s
+
+
+def bench_decimal_pi():
+    for prec in [9, 19]:
+        decimal.getcontext().prec = prec
+        for _ in range(10000):
+            _ = pi_decimal()
+
+
+if __name__ == "__main__":
+    runner = pyperf.Runner()
+    runner.metadata["description"] = "decimal_pi benchmark"
+
+    args = runner.parse_args()
+    runner.bench_func("decimal_pi", bench_decimal_pi)


### PR DESCRIPTION
These currently exist in the [CPython source](https://github.com/python/cpython/blob/main/Modules/_decimal/tests/bench.py), but it would be good to have them here for continuous benchmarking.