### PR TITLE
Drop support for Python 3.7 and 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         # Test all supported versions on Ubuntu:
         os: [ubuntu-latest]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
         experimental: [false]
         build: ['']
         include:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,7 @@ name: test
 
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
   schedule:
     # Midnight UTC:
     - cron: "0 0 * * *"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Set up Python ${{ matrix.python }} using deadsnakes
-      uses: deadsnakes/action@v3.1.0
+      uses: deadsnakes/action@v3.2.0
       if: "endsWith(matrix.python, '-dev')"
       with:
         python-version: ${{ matrix.python }}

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,10 +1,6 @@
 name: mypy
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 permissions:
   contents: read

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -18,8 +18,8 @@ jobs:
     name: Check code with mypy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           cache: "pip"
           cache-dependency-path: "pyproject.toml"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,9 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
         cache: pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ classifiers = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python',
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
     "pyperf",
     "tomli; python_version < '3.11'",
@@ -85,7 +85,7 @@ find = {}  # Scanning implicit namespaces is active by default
 version = {attr = "pyperformance.__version__"}
 
 [tool.mypy]
-python_version = "3.7"
+python_version = "3.9"
 pretty = true
 enable_error_code = "ignore-without-code"
 disallow_any_generics = true


### PR DESCRIPTION
Python 3.8 is end-of-life next month:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0569/#lifespan

Many of the files under `pyperformance/data-files/benchmarks/` have `requires-python = ">=3.7"` or `requires-python = ">=3.8"` but I've not changed them.