### PR TITLE
Update MANIFEST

### DIFF
--- a/pyperformance/data-files/benchmarks/MANIFEST
+++ b/pyperformance/data-files/benchmarks/MANIFEST
@@ -94,14 +94,11 @@ unpickle_pure_python	<local:pickle>
 xml_etree	<local>
 
 
-#[groups]
-#asyncio
-#startup
-#regex
-#serialize
-#apps
-#math
-#template
-
-
 [group default]
+[group asyncio]
+[group startup]
+[group regex]
+[group serialize]
+[group apps]
+[group math]
+[group template]


### PR DESCRIPTION
According to https://pyperformance.readthedocs.io/benchmarks.html#available-groups

As it stands by using the default manifest these groups are disabled. This PR is to re-enable their selection. I've tested this locally and it looks like it's working