### PR TITLE
Fix a docstring in async_tree benchmark

### DIFF
--- a/pyperformance/data-files/benchmarks/bm_async_tree/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_async_tree/run_benchmark.py
@@ -6,7 +6,7 @@ variants include:
 
 1) "none": No actual async work in the async tree.
 2) "io": All leaf nodes simulate async IO workload (async sleep 50ms).
-3) "memoization": All leaf nodes simulate async IO workload with 90% of
+3) "memoization": All leaf nodes simulate async IO workload with 90%% of
                   the data memoized
 4) "cpu_io_mixed": Half of the leaf nodes simulate CPU-bound workload and
                    the other half simulate the same workload as the


### PR DESCRIPTION
Since https://github.com/python/cpython/pull/124899, argparse help strings are more strict, and will fail with invalid `%` format strings.