### PR TITLE
Fix function to get if pyperformance is installed in editable mode

### DIFF
--- a/pyperformance/__init__.py
+++ b/pyperformance/__init__.py
@@ -20,7 +20,7 @@ def is_installed():
 
 def is_dev():
     parent = os.path.dirname(PKG_ROOT)
-    return os.path.exists(os.path.join(parent, 'setup.py'))
+    return os.path.exists(os.path.join(parent, 'pyproject.toml'))
 
 
 def _is_venv():


### PR DESCRIPTION
This is used in `compile.py`: `compile_all` installs pyperformance for every version it compiles. If the main pyperformance is installed in editable mode, this should be propagated down.
The mechamism to do that was broken because was checking the presence of `setup.py`, now long gone.