### PR TITLE
Make benchmarking 25% faster by parallelizing benchmarking venv setup

### DIFF
--- a/pyperformance/run.py
+++ b/pyperformance/run.py
@@ -142,7 +142,7 @@ def run_benchmarks(should_run, python, options):
     executor_input = [(i+1, len(to_run), python, options, bench)
                       for i, bench in enumerate(to_run[1:])]
     # It's fine to set a higher worker count, because this is IO-bound anyways.
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, len(to_run))) as executor:
+    with concurrent.futures.ProcessPoolExecutor() as executor:
         for bench, venv_root, venv, bench_runid, cons_output in list(executor.map(setup_single_venv, executor_input)):
             if venv_root is not None:
                 venvs.add(venv_root)

--- a/pyperformance/run.py
+++ b/pyperformance/run.py
@@ -142,8 +142,8 @@ def run_benchmarks(should_run, python, options):
     executor_input = [(i+1, len(to_run), python, options, bench)
                       for i, bench in enumerate(to_run[1:])]
     # It's fine to set a higher worker count, because this is IO-bound anyways.
-    with concurrent.futures.ProcessPoolExecutor(max_workers=max(1, len(to_run))) as executor:
-        for bench, venv_root, venv, bench_runid, cons_output in executor.map(setup_single_venv, executor_input):
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, len(to_run))) as executor:
+        for bench, venv_root, venv, bench_runid, cons_output in list(executor.map(setup_single_venv, executor_input)):
             if venv_root is not None:
                 venvs.add(venv_root)
             benchmarks[bench] = (venv, bench_runid) 

--- a/pyperformance/run.py
+++ b/pyperformance/run.py
@@ -142,7 +142,7 @@ def run_benchmarks(should_run, python, options):
     executor_input = [(i+1, len(to_run), python, options, bench)
                       for i, bench in enumerate(to_run[1:])]
     # It's fine to set a higher worker count, because this is IO-bound anyways.
-    with concurrent.futures.ProcessPoolExecutor(max_workers=len(to_run)-1) as executor:
+    with concurrent.futures.ProcessPoolExecutor(max_workers=max(1, len(to_run))) as executor:
         for bench, venv_root, venv, bench_runid, cons_output in executor.map(setup_single_venv, executor_input):
             if venv_root is not None:
                 venvs.add(venv_root)


### PR DESCRIPTION
Fixes https://github.com/python/pyperformance/issues/374.

On my computer it takes roughly 90 minutes for a single pyperformance run.

Setting up (compiling and venv installation) takes 45 minutes. We can cut that down.

Before (no compilation, just installation):
```
real    31m40.161s
user    1m23.838s
sys     0m9.785s
```
After:
```
real    6m45.913s
user    3m37.286s
sys     0m22.162s
```

Roughly 5x faster setup (without compilation). Saving roughly 25 minutes, and thus 25% (roughly) of benchmarking time.

Edit: this only applies to older pip (22 and below)