### PR TITLE
.github: Add ARM64 CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         # Test all supported versions on Ubuntu:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm]
         python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         experimental: [false]
         build: ['']

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,14 +37,7 @@ jobs:
           - os: ubuntu-latest
             python: "3.14-dev"
             experimental: true
-          - os: ubuntu-24.04-arm
-            python: "3.14-dev"
-            experimental: true
           - os: ubuntu-latest
-            python: "3.14-dev"
-            experimental: true
-            build: 'free-threading'
-          - os: ubuntu-24.04-arm
             python: "3.14-dev"
             experimental: true
             build: 'free-threading'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,13 +27,24 @@ jobs:
         include:
           # As the experimental task for the dev version.
           - os: ubuntu-latest
-            python: "3.13-dev"
+            python: "3.13"
+            experimental: true
+            build: 'free-threading'
+          - os: ubuntu-24.04-arm
+            python: "3.13"
             experimental: true
             build: 'free-threading'
           - os: ubuntu-latest
             python: "3.14-dev"
             experimental: true
+          - os: ubuntu-24.04-arm
+            python: "3.14-dev"
+            experimental: true
           - os: ubuntu-latest
+            python: "3.14-dev"
+            experimental: true
+            build: 'free-threading'
+          - os: ubuntu-24.04-arm
             python: "3.14-dev"
             experimental: true
             build: 'free-threading'


### PR DESCRIPTION
See: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/ and https://github.com/psf/pyperf/pull/212