### PR TITLE
Try skipping dependenabot updates on benchmarks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,14 @@ updates:
     directory: "/pyperformance/requirements"
     schedule:
       interval: "monthly"
+  # Don't update test dependencies for reproducibility.
+  # Dependabot doesn't support excluding directories
+  # (https://github.com/dependabot/dependabot-core/issues/4364)
+  # however, we can ignore all dependencies in the data-files
+  # directory which is equivalent if a bit slower
+  - package-ecosystem: "pip"
+    directory: "/pyperformance/data-files"
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
Wanted to see if this might skip the benchmark dependencies which we want to keep stable.

See https://github.com/python/pyperformance/issues/223 for context.