### PR TITLE
Pass --warmup along to pyperf

### DIFF
--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -101,7 +101,7 @@ def parse_args():
                      choices=hook_names,
                      metavar=f"{', '.join(x for x in hook_names if not x.startswith('_'))}",
                      help="Apply the given pyperf hook(s) when running each benchmark")
-    cmd.add_argument("--warmups",
+    cmd.add_argument("--warmups", type=int, default=None,
                      help="number of skipped values per run used to warmup the benchmark")
     filter_opts(cmd)
 

--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -101,6 +101,8 @@ def parse_args():
                      choices=hook_names,
                      metavar=f"{', '.join(x for x in hook_names if not x.startswith('_'))}",
                      help="Apply the given pyperf hook(s) when running each benchmark")
+    cmd.add_argument("--warmups",
+                     help="number of skipped values per run used to warmup the benchmark")
     filter_opts(cmd)
 
     # show

--- a/pyperformance/run.py
+++ b/pyperformance/run.py
@@ -247,6 +247,7 @@ def get_pyperf_opts(options):
     if options.hook:
         for hook in options.hook:
             opts.append('--hook=%s' % hook)
+    # --warmups=0 is a valid option, so check for `not None` here
     if options.warmups is not None:
         opts.append('--warmups=%s' % options.warmups)
 

--- a/pyperformance/run.py
+++ b/pyperformance/run.py
@@ -247,5 +247,7 @@ def get_pyperf_opts(options):
     if options.hook:
         for hook in options.hook:
             opts.append('--hook=%s' % hook)
+    if options.warmup:
+        opts.append('--warmup=%s' % options.warmup)
 
     return opts

--- a/pyperformance/run.py
+++ b/pyperformance/run.py
@@ -247,7 +247,7 @@ def get_pyperf_opts(options):
     if options.hook:
         for hook in options.hook:
             opts.append('--hook=%s' % hook)
-    if options.warmup:
-        opts.append('--warmup=%s' % options.warmup)
+    if options.warmups is not None:
+        opts.append('--warmups=%s' % options.warmups)
 
     return opts


### PR DESCRIPTION
When running pystats collection, it is useful to /not/ do warmup runs so we don't "miss" any of the stats.  This requires being able pass the `--warmups` argument to the underlying pyperf.