### PR TITLE
Free-threading treatment for PyList_GET_ITEM

### DIFF
--- a/pyperformance/data-files/benchmarks/bm_sphinx/data/Doc/howto/free-threading-extensions.rst
+++ b/pyperformance/data-files/benchmarks/bm_sphinx/data/Doc/howto/free-threading-extensions.rst
@@ -151,6 +151,8 @@ that return :term:`strong references <strong reference>`.
 +===================================+===================================+
 | :c:func:`PyList_GetItem`          | :c:func:`PyList_GetItemRef`       |
 +-----------------------------------+-----------------------------------+
+| :c:func:`PyList_GET_ITEM`         | :c:func:`PyList_GetItemRef`       |
++-----------------------------------+-----------------------------------+
 | :c:func:`PyDict_GetItem`          | :c:func:`PyDict_GetItemRef`       |
 +-----------------------------------+-----------------------------------+
 | :c:func:`PyDict_GetItemWithError` | :c:func:`PyDict_GetItemRef`       |


### PR DESCRIPTION
`PyList_GET_ITEM` should be treated akin to `PyList_GetItem` when it comes to free-threading considerations.

Matching PR: https://github.com/python/peps/pull/4507