### PR TITLE
Add pre-commit, `ruff check` configuration and Github action

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check code with ruff
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/ruff-action@v3
         with:
           args: "check"

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,16 @@
+name: ruff
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+
+jobs:
+  ruff:
+    name: Check code with ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: "check"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.11
+    hooks:
+      - id: ruff-check
+        name: Run Ruff (lint)
+        args: [--exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,9 @@ exclude = [
 module = "pyperf"
 ignore_missing_imports = true
 
+[tool.ruff]
+target-version = "py310"
+
 [tool.ruff.lint]
 ignore = [
     "E402",  # module level import not at top of file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,3 +104,18 @@ exclude = [
 [[tool.mypy.overrides]]
 module = "pyperf"
 ignore_missing_imports = true
+
+[tool.ruff.lint]
+ignore = [
+    "E402",  # module level import not at top of file
+    "E501",  # line too long
+    "E701",  # multiple statements on one line (colon)
+    "E722",  # do not use bare 'except'
+    "E741",  # ambiguous variable name
+    "F405"   # name may be undefined, or defined from star imports
+]
+
+select = [
+    "E",
+    "F",
+]


### PR DESCRIPTION
After #404, I ran `uvx ruff check` and found a lot of not so subtle errors:

```
12:33:31.816619000AM CEST maurycy@gimel /Users/maurycy/src/pyperformance % uvx ruff check --output-format concise
pyperformance/_benchmark.py:4:5: F822 Undefined name `Benchmarkcheck_name` in `__all__`
pyperformance/_benchmark.py:221:67: F821 Undefined name `NOOP`
pyperformance/_benchmark_metadata.py:197:13: F841 Local variable `repo` is assigned to but never used
pyperformance/_manifest.py:346:17: F821 Undefined name `seclines`
pyperformance/_manifest.py:366:9: F841 Local variable `yielded` is assigned to but never used
pyperformance/_pyproject_toml.py:103:15: F821 Undefined name `ValuError`
pyperformance/_pyproject_toml.py:125:30: F541 [*] f-string without any placeholders
pyperformance/_pyproject_toml.py:129:9: F841 Local variable `text` is assigned to but never used
pyperformance/_utils.py:9:5: F822 Undefined name `run_command` in `__all__`
pyperformance/data-files/benchmarks/bm_2to3/run_benchmark.py:20:16: F401 `lib2to3` imported but unused; consider using `importlib.util.find_spec` to test for availability
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/btm_matcher.py:162:16: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/btm_utils.py:170:17: F841 Local variable `leaf` is assigned to but never used
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/fixes/fix_except.py:48:9: F841 Local variable `syms` is assigned to but never used
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/fixes/fix_exec.py:28:9: F841 Local variable `syms` is assigned to but never used
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/fixes/fix_exitfunc.py:66:13: F841 Local variable `stmt_container` is assigned to but never used
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/fixes/fix_has_key.py:80:9: F841 Local variable `anchor` is assigned to but never used
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/fixes/fix_itertools_imports.py:22:17: F841 Local variable `member` is assigned to but never used
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/fixes/fix_urllib.py:49:5: F841 Local variable `bare` is assigned to but never used
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/fixes/fix_urllib.py:129:21: F841 Local variable `as_name` is assigned to but never used
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/pgen2/pgen.py:160:13: F841 Local variable `oldlen` is assigned to but never used
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/pgen2/pgen.py:162:13: F841 Local variable `newlen` is assigned to but never used
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/pgen2/tokenize.py:32:1: E401 [*] Multiple imports on one line
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/pgen2/tokenize.py:34:1: F403 `from lib2to3.pgen2.token import *` used; unable to detect undefined names
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/pgen2/tokenize.py:492:25: F841 Local variable `strstart` is assigned to but never used
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/pygram.py:10:20: F401 [*] `.pgen2.token` imported but unused
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/pygram.py:12:15: F401 [*] `.pytree` imported but unused
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/pytree.py:28:16: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
pyperformance/data-files/benchmarks/bm_2to3/vendor/src/lib2to3/refactor.py:460:44: E713 [*] Test for membership should be `not in`
pyperformance/data-files/benchmarks/bm_barnes_hut/run_benchmark.py:342:5: F841 Local variable `initial_energy` is assigned to but never used
pyperformance/data-files/benchmarks/bm_barnes_hut/run_benchmark.py:353:9: F841 Local variable `final_energy` is assigned to but never used
pyperformance/data-files/benchmarks/bm_dask/run_benchmark.py:8:18: F401 [*] `dask.distributed` imported but unused
pyperformance/data-files/benchmarks/bm_gc_traversal/run_benchmark.py:21:5: F841 Local variable `all_cycles` is assigned to but never used
pyperformance/data-files/benchmarks/bm_sphinx/data/Doc/conf.py:15:13: F541 [*] f-string without any placeholders
pyperformance/run.py:205:25: F821 Undefined name `os`
pyperformance/tests/test_commands.py:105:13: F841 Local variable `text` is assigned to but never used
pyperformance/tests/test_commands.py:111:13: F841 Local variable `text` is assigned to but never used
pyperformance/tests/test_commands.py:151:9: F841 Local variable `text` is assigned to but never used
Found 37 errors.
[*] 7 fixable with the `--fix` option (20 hidden fixes can be enabled with the `--unsafe-fixes` option).
```