### PR TITLE
`ruff` linter: remove all ignores except E501

### DIFF
--- a/pyperformance/_manifest.py
+++ b/pyperformance/_manifest.py
@@ -313,8 +313,8 @@ def _parse_benchmarks_section(lines):
     version = origin = None
     for line in lines:
         try:
-            name, metafile = (None if l == '-' else l
-                              for l in line.split('\t'))
+            name, metafile = (None if field == '-' else field
+                              for field in line.split('\t'))
         except ValueError:
             raise ValueError(f'bad benchmark line {line!r}')
         spec = _benchmark.BenchmarkSpec(name or None, version, origin)

--- a/pyperformance/_utils.py
+++ b/pyperformance/_utils.py
@@ -24,6 +24,8 @@ import os
 import os.path
 import shlex
 import shutil
+import subprocess
+import sys
 import tempfile
 import urllib.request
 
@@ -80,9 +82,6 @@ def safe_rmtree(path):
 
 #######################################
 # platform utils
-
-import subprocess
-import sys
 
 
 MS_WINDOWS = (sys.platform == 'win32')

--- a/pyperformance/_venv.py
+++ b/pyperformance/_venv.py
@@ -43,7 +43,7 @@ def parse_venv_config(lines, root=None):
     if isinstance(lines, str):
         lines = lines.splitlines()
     else:
-        lines = (l.rstrip(os.linesep) for l in lines)
+        lines = (line.rstrip(os.linesep) for line in lines)
 
     cfg = types.SimpleNamespace(
         home=None,

--- a/pyperformance/tests/test_venv.py
+++ b/pyperformance/tests/test_venv.py
@@ -47,7 +47,7 @@ def render_venv_config(cfg):
         lines.append(f'executable = {cfg.executable}')
     if cfg.command is not None:
         lines.append(f'command = {cfg.command}')
-    return ''.join(l + os.linesep for l in lines)
+    return ''.join(line + os.linesep for line in lines)
 
 
 class VenvConfigTests(tests.Functional, unittest.TestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,12 +102,7 @@ lint.select = [
   "F", # pyflakes errors
 ]
 lint.ignore = [
-  "E402", # module level import not at top of file
   "E501", # line too long
-  "E701", # multiple statements on one line (colon)
-  "E722", # do not use bare 'except'
-  "E741", # ambiguous variable name
-  "F405", # name may be undefined, or defined from star imports
 ]
 
 [tool.pyproject-fmt]


### PR DESCRIPTION
This is a quick follow up to #405.

The focus of #405 was adding pre-commit, `ruff check` and Github action, without doing too many changes to the code.

This PR finishes the `uvx ruff check` checks, except E501, as discussed in:

https://github.com/python/pyperformance/pull/405#issuecomment-3245226963

The PR is much shorted than expected because we exclude the benchmarks:

https://github.com/python/pyperformance/blob/main/.pre-commit-config.yaml#L8