### PR TITLE
Exclude benchmarks from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/pyperformance/requirements"
     schedule:
       interval: "monthly"
+    exclude-paths:
+      - "pyperformance/data-files/"


### PR DESCRIPTION
It was discussed in #223 and @mdboom wanted to exclude benchmarks from dependabot. The feature wasn't available then, but we're lucky, and it does now:

- https://github.blog/changelog/2025-08-26-dependabot-can-now-exclude-automatic-pull-requests-for-manifests-in-selected-subdirectories/
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#exclude-paths-