### PR TITLE
Incorrect `isinstance(readme, 'str')` check

### DIFF
--- a/pyperformance/_pyproject_toml.py
+++ b/pyperformance/_pyproject_toml.py
@@ -167,7 +167,7 @@ def _normalize_project(data, rootdir, name, requirefiles, **_ignored):
     key = 'readme'
     if key in data:
         readme = data[key]
-        if isinstance(readme, 'str'):
+        if isinstance(readme, str):
             readme = data[key] = {'file': readme}
         # XXX Check the suffix.
         # XXX Handle 'content-type'.


### PR DESCRIPTION
`'str'` is incorrect there:

```
>>> isinstance('meow', 'str')
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    isinstance('meow', 'str')
    ~~~~~~~~~~^^^^^^^^^^^^^^^
TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
>>> isinstance('meow', str)
True
```