### PR TITLE
Drop support for Python 3.9, test PyPy3.11 instead of PyPy3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
             build: 'free-threading'
           # Also test PyPy, macOS, and Windows:
           - os: ubuntu-latest
-            python: pypy-3.10
+            python: pypy-3.11
             experimental: false
           - os: macos-latest
             python: "3.13"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         # Test all supported versions on Ubuntu:
         os: [ubuntu-latest, ubuntu-24.04-arm]
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13"]
         experimental: [false]
         build: ['']
         include:
@@ -44,9 +44,6 @@ jobs:
           # Also test PyPy, macOS, and Windows:
           - os: ubuntu-latest
             python: pypy-3.10
-            experimental: false
-          - os: ubuntu-latest
-            python: pypy-3.9
             experimental: false
           - os: macos-latest
             python: "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ description = "Python benchmark suite"
 readme = "README.rst"
 license = { text = "MIT" }
 authors = [ { name = "Collin Winter" }, { name = "Jeffrey Yasskin" } ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -57,7 +57,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -109,7 +108,7 @@ lint.ignore = [
 max_supported_python = "3.14"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 pretty = true
 enable_error_code = "ignore-without-code"
 disallow_any_generics = true


### PR DESCRIPTION
It's almost end-of-life:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0596/

Also move CI from PyPy3.10 to PyPy3.11 because PyPy only includes PyPy3.11 in the latest releases: https://pypy.org/posts/2025/07/pypy-v7320-release.html