### PR TITLE
Update GitHub Actions using Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 10
+
   - package-ecosystem: "pip"
     directory: "/"
     exclude-paths:


### PR DESCRIPTION
We're already using Dependabot for Python/pip dependencies, let's also use it for keeping GitHub Actions up to date.

This config is similar to what we use in blurb, cherry picker and so on.