### PR TITLE
Fix workflow `ubuntu-latest - 3.15-dev free-threading` test failing

### DIFF
--- a/pyperformance/requirements/requirements.txt
+++ b/pyperformance/requirements/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file=pyperformance/requirements/requirements.txt requirements.in
 #
-packaging==23.1
+packaging>=24.1
     # via -r requirements.in
-psutil==5.9.5
+psutil==7.0.0
     # via
     #   -r requirements.in
     #   pyperf


### PR DESCRIPTION
The error is gone:

- https://github.com/python/pyperformance/actions/runs/18809708747?pr=427
- https://github.com/python/pyperformance/actions/runs/18809708747/job/53669008120?pr=427

That's how it looked:

- https://github.com/python/pyperformance/actions/runs/18779843038
- https://github.com/python/pyperformance/actions/runs/18779843038/job/53582979451

ref #426 #394 #395