### PR TITLE
Group Dependabot updates for GitHub Actions into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
-    open-pull-requests-limit: 10
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
Follow up from https://github.com/python/pyperformance/pull/419.

We don't really need separate PRs like https://github.com/python/pyperformance/pull/429 and https://github.com/python/pyperformance/pull/430, a single PR is usually fine, and also avoids merge conflicts as happened in those.