### PR TITLE
Do not `venv.ensure_reqs` twice

### DIFF
--- a/pyperformance/commands.py
+++ b/pyperformance/commands.py
@@ -155,6 +155,7 @@ def cmd_venv_show(options, root):
 
 def cmd_run(options, benchmarks):
     import pyperf
+
     import pyperformance
 
     from .compare import display_benchmark_suite


### PR DESCRIPTION
Found it already in https://github.com/python/pyperformance/pull/425/files#diff-ed8495a8737f359ec47d7efca6e234fa871a8653abfa5f014816d1be7cf8c3a5R91