### PR TITLE
Add support for GraalPy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
             python: pypy-3.11
             experimental: false
           - os: ubuntu-latest
-            python: graalpy-24.0
+            python: graalpy-25.0.0
             experimental: true
           - os: macos-latest
             python: "3.14"


### PR DESCRIPTION
It's an alternative Python implementation, as per https://github.com/python/pythondotorg/issues/2797 and supported by https://github.com/actions/setup-python