### PR TITLE
Fix `pyperformance venv` (w/o any subcommand) exception

### DIFF
--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -244,6 +244,7 @@ def parse_args():
         "venv", parents=[venv_common], help="Actions on the virtual environment"
     )
     cmd.set_defaults(venv_action="show")
+    cmds.append(cmd)
     venvsubs = cmd.add_subparsers(dest="venv_action")
     cmd = venvsubs.add_parser("show", parents=[venv_common])
     cmds.append(cmd)

--- a/pyperformance/cli.py
+++ b/pyperformance/cli.py
@@ -387,7 +387,8 @@ def _main():
         elif action == "show":
             cmd_venv_show(options, root)
         else:
-            print(f"ERROR: unsupported venv command action {action!r}")
+            if action is not None:
+                print(f"ERROR: unsupported venv command action {action!r}")
             parser.print_help()
             sys.exit(1)
     elif options.action == "compile":


### PR DESCRIPTION
Now:

```
2026-01-26T19:29:17.403748000+0100 maurycy@gimel /Users/maurycy/work/pyperformance (fix-428-venv) % uv run --python 3.14 --with . python -m pyperformance venv
usage: pyperformance [-h] [-V] {run,show,compare,list,list_groups,compile,compile_all,upload,venv} ...

Compares the performance of baseline_python with changed_python and prints a report.

positional arguments:
  {run,show,compare,list,list_groups,compile,compile_all,upload,venv}
    run                 Run benchmarks on the running python
    show                Display a benchmark file
    compare             Compare two benchmark files
    list                List benchmarks of the running Python
    list_groups         List benchmark groups of the running Python
    compile             Compile and install CPython and run benchmarks on installed Python
    compile_all         Compile and install CPython and run benchmarks on installed Python on all branches and revisions of CONFIG_FILE
    upload              Upload JSON results to a Codespeed website
    venv                Actions on the virtual environment

options:
  -h, --help            show this help message and exit
  -V, --version         show program's version number and exit
```

Before:

```
[1] 2026-03-23T10:53:38.530937000+0100 maurycy@gimel /Users/maurycy/src/github.com/maurycy/pyperformance (main) % uv run --python 3.14 --with . python -m pyperformance venv
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/maurycy/src/github.com/maurycy/pyperformance/pyperformance/__main__.py", line 3, in <module>
    pyperformance.cli.main()
    ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/maurycy/src/github.com/maurycy/pyperformance/pyperformance/cli.py", line 422, in main
    _main()
    ~~~~~^^
  File "/Users/maurycy/src/github.com/maurycy/pyperformance/pyperformance/cli.py", line 371, in _main
    info = _pythoninfo.get_info(options.python)
                                ^^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'python'
```

Fixes #428 