### PR TITLE
Support PyPy `_pickle` accelerator in `bm_pickle`

### DIFF
--- a/pyperformance/data-files/benchmarks/bm_pickle/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_pickle/run_benchmark.py
@@ -266,10 +266,10 @@ if __name__ == "__main__":
     if options.pure_python:
         name += "_pure_python"
 
-    if not (options.pure_python or IS_PYPY):
+    if not (options.pure_python):
         # C accelerators are enabled by default on 3.x
         import pickle
-        if not is_accelerated_module(pickle):
+        if not is_accelerated_module(pickle) and not IS_PYPY:
             raise RuntimeError("Missing C accelerators for pickle")
     else:
         sys.modules['_pickle'] = None


### PR DESCRIPTION
I am working on adding a _pickle RPython implementation to PyPy. I ran into a problem where the current benchmark will ignore that possibility and will always use the pure-python version on PyPy. This PR makes the logic work for the case that PyPy does have a _pickle module and, like CPython, it is activated by default, but retains backward compatibility.