### PR TITLE
Swap benchmark names for argparse benchmarks

### DIFF
--- a/pyperformance/data-files/benchmarks/bm_argparse/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_argparse/run_benchmark.py
@@ -17,7 +17,7 @@ def generate_arguments(i: int) -> list:
     return arguments
 
 
-def bm_many_optionals() -> argparse.ArgumentParser:
+def bm_subparsers() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="A version control system CLI")
 
     parser.add_argument("--version", action="version", version="1.0")
@@ -83,7 +83,7 @@ def bm_many_optionals() -> argparse.ArgumentParser:
         parser.parse_args(arguments)
 
 
-def bm_subparsers() -> argparse.ArgumentParser:
+def bm_many_optionals() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
 
     parser.add_argument("input_file", type=str, help="The input file")


### PR DESCRIPTION
So, I really don't know how this happened but apparently when I added the argparse benchmarks in #367, I flipped the function names.

The BENCHMARKS dict mapped "many_optionals" → bm_many_optionals and "subparsers" → bm_subparsers, so the public benchmark IDs (argparse_many_optionals, argparse_subparsers) ran the opposite workload from what their names imply.

This PR correctly renames them but obviously, this means that in the next version of pyperformance, results will be quite different. If folks have ideas on how to better handle the discontinuity, please let me know. Apologies for the churn here!

Kudos to @chris-eibl for pointing this out ❤️ 