### PR TITLE
add db cleanup for PyPy

### DIFF
--- a/pyperformance/data-files/benchmarks/bm_sqlalchemy_declarative/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_sqlalchemy_declarative/run_benchmark.py
@@ -62,6 +62,7 @@ def bench_sqlalchemy(loops, npeople):
         # drop rows created by the previous benchmark
         session.query(Person).delete(synchronize_session=False)
         session.query(Address).delete(synchronize_session=False)
+        session.expunge_all()
 
         # Run the benchmark once
         t0 = pyperf.perf_counter()

--- a/pyperformance/data-files/benchmarks/bm_sqlalchemy_declarative/run_benchmark.py
+++ b/pyperformance/data-files/benchmarks/bm_sqlalchemy_declarative/run_benchmark.py
@@ -50,7 +50,6 @@ DBSession = sessionmaker(bind=engine)
 # session.commit(). If you're not happy about the changes, you can
 # revert all of them back to the last commit by calling
 # session.rollback()
-session = DBSession()
 
 
 # add 'npeople' people to the database
@@ -59,30 +58,30 @@ def bench_sqlalchemy(loops, npeople):
     total_dt = 0.0
 
     for loops in range(loops):
+        with DBSession() as session:
         # drop rows created by the previous benchmark
-        session.query(Person).delete(synchronize_session=False)
-        session.query(Address).delete(synchronize_session=False)
-        session.expunge_all()
+            session.query(Person).delete(synchronize_session=False)
+            session.query(Address).delete(synchronize_session=False)
 
-        # Run the benchmark once
-        t0 = pyperf.perf_counter()
+            # Run the benchmark once
+            t0 = pyperf.perf_counter()
 
-        for i in range(npeople):
-            # Insert a Person in the person table
-            new_person = Person(name="name %i" % i)
-            session.add(new_person)
-            session.commit()
+            for i in range(npeople):
+                # Insert a Person in the person table
+                new_person = Person(name="name %i" % i)
+                session.add(new_person)
+                session.commit()
 
-            # Insert an Address in the address table
-            new_address = Address(post_code='%05i' % i, person=new_person)
-            session.add(new_address)
-            session.commit()
+                # Insert an Address in the address table
+                new_address = Address(post_code='%05i' % i, person=new_person)
+                session.add(new_address)
+                session.commit()
 
-        # do 100 queries per insert
-        for i in range(npeople):
-            session.query(Person).all()
+            # do 100 queries per insert
+            for i in range(npeople):
+                session.query(Person).all()
 
-        total_dt += (pyperf.perf_counter() - t0)
+            total_dt += (pyperf.perf_counter() - t0)
 
     return total_dt
 


### PR DESCRIPTION
Claude helped me come up with this fix for hundreds of emitted warnings, with the justification:

SQLite reuses primary key IDs after a full table DELETE (it has no AUTOINCREMENT sequence to preserve), the next loop iteration inserts new Person and Address objects with the same IDs (1..N) as the previous run.

On CPython this is harmless: refcounting immediately collects the old objects when new_person is reassigned each iteration, clearing the identity map's weakrefs before the next loop. On PyPy, GC is deferred - the old objects remain alive, so the identity map still holds live entries for IDs 1..N. When the new objects are committed with the same keys, SQLAlchemy's `_register_persistent` detects the collision and emits:

`SAWarning: Identity map already had an identity for (Person, (1,), None), replacing it with newly flushed object. Are there load operations occurring inside of an event handler within the flush?`

This warning fires for every inserted row on every benchmark loop, flooding stderr and causing the benchmark to fail on PyPy.

  Fix: call `session.expunge_all()` immediately after the bulk deletes to explicitly clear the stale session state before timing begins.

It would be nice to have someone who understands more about sqlalchemy than me review this for correctness, I am not sure this is the right place for a fix.