### PR TITLE
Fix --same-loops flag in compile subprocess invocation

### DIFF
--- a/pyperformance/compile.py
+++ b/pyperformance/compile.py
@@ -571,7 +571,7 @@ class BenchmarkRevision(Application):
         if self.conf.debug:
             cmd.append("--debug-single-value")
         if self.conf.same_loops:
-            cmd.append("--same_loops=%s" % self.conf.same_loops)
+            cmd.append("--same-loops=%s" % self.conf.same_loops)
         if self.conf.rigorous:
             cmd.append("--rigorous")
         exitcode = self.run_nocheck(*cmd)


### PR DESCRIPTION
When the compile subcommand spawns a "pyperformance run" subprocess, it constructs --same_loops on the command line where argparse only accepts --same-loops. Change the flag to use the hyphenated form.